### PR TITLE
fix bug: initializing plugin failed by cannot unwrap existing key.

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Oct 31 22:18:00 SGT 2017
+#Thu Sep 20 15:16:53 ICT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipher18Implementation.java
+++ b/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipher18Implementation.java
@@ -120,6 +120,7 @@ class RSACipher18Implementation {
             spec = new KeyGenParameterSpec.Builder(KEY_ALIAS, KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)
                     .setCertificateSubject(new X500Principal("CN=" + KEY_ALIAS))
                     .setDigests(KeyProperties.DIGEST_SHA256)
+                    .setBlockModes(KeyProperties.BLOCK_MODE_ECB)
                     .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
                     .setCertificateSerialNumber(BigInteger.valueOf(1))
                     .setCertificateNotBefore(start.getTime())

--- a/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipher18Implementation.java
+++ b/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipher18Implementation.java
@@ -38,12 +38,14 @@ public class StorageCipher18Implementation implements StorageCipher {
         cipher = Cipher.getInstance("AES/CBC/PKCS7Padding");
 
         if (aesKey != null) {
+            byte[] encrypted;
             try {
-                byte[] encrypted = Base64.decode(aesKey, Base64.DEFAULT);
+                encrypted = Base64.decode(aesKey, Base64.DEFAULT);
                 secretKey = rsaCipher.unwrap(encrypted, KEY_ALGORITHM);
                 return;
             } catch (Exception e) {
                 Log.e("StorageCipher18Impl", "unwrap key failed", e);
+                encrypted = new byte[0];
             }
         }
 


### PR DESCRIPTION
Related to bug #21 , that's a weird case when existing AES key cannot be unwrapped, so I add some codes to catch this error and re-create a new key in this case.