### PR TITLE
Add version check for setIsStrongBoxBacked.

### DIFF
--- a/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipher18Implementation.java
+++ b/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipher18Implementation.java
@@ -137,16 +137,20 @@ class RSACipher18Implementation {
                     .setEndDate(end.getTime())
                     .build();
         } else {
-            spec = new KeyGenParameterSpec.Builder(KEY_ALIAS, KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)
+            KeyGenParameterSpec.Builder builder = new KeyGenParameterSpec.Builder(KEY_ALIAS, KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)
                     .setCertificateSubject(new X500Principal("CN=" + KEY_ALIAS))
                     .setDigests(KeyProperties.DIGEST_SHA256)
                     .setBlockModes(KeyProperties.BLOCK_MODE_ECB)
                     .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
                     .setCertificateSerialNumber(BigInteger.valueOf(1))
                     .setCertificateNotBefore(start.getTime())
-                    .setCertificateNotAfter(end.getTime())
-                    .setIsStrongBoxBacked(true)
-                    .build();
+                    .setCertificateNotAfter(end.getTime());
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                builder.setIsStrongBoxBacked(true);
+            }
+
+            spec = builder.build();
         }
         try {
             kpGenerator.initialize(spec);

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -16,8 +16,8 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
 
     lintOptions {
         disable 'InvalidPackage'
@@ -27,7 +27,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.it_nomads.fluttersecurestorageexample"
         minSdkVersion 18
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
Fix exception 
```
E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.it_nomads.fluttersecurestorageexample, PID: 19495
    java.lang.NoSuchMethodError: No virtual method setIsStrongBoxBacked(Z)Landroid/security/keystore/KeyGenParameterSpec$Builder; in class Landroid/security/keystore/KeyGenParameterSpec$Builder; or its super classes (declaration of 'android.security.keystore.KeyGenParameterSpec$Builder' appears in /system/framework/framework.jar!classes2.dex)
        at com.it_nomads.fluttersecurestorage.ciphers.RSACipher18Implementation.createKeys(RSACipher18Implementation.java:148)
        at com.it_nomads.fluttersecurestorage.ciphers.RSACipher18Implementation.createRSAKeysIfNeeded(RSACipher18Implementation.java:115)
...
```