### PR TITLE
Added minimum sdk requirement on AndroidManifest

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,1 +1,4 @@
-<manifest package="com.it_nomads.fluttersecurestorage" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.it_nomads.fluttersecurestorage">
+  <uses-sdk android:minSdkVersion="18" />
+</manifest>


### PR DESCRIPTION
Currently flutter supports a minimum SDK version of 16 and all plugins should be able to match it, anything lower than that will probably cause some unwanted issues. We need to add those into Android Manifest and properly document it.