### PR TITLE
Fix #58; fix No certificate found under alias

### DIFF
--- a/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipher18Implementation.java
+++ b/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipher18Implementation.java
@@ -110,8 +110,16 @@ class RSACipher18Implementation {
         KeyStore ks = KeyStore.getInstance(KEYSTORE_PROVIDER_ANDROID);
         ks.load(null);
 
-        Key privateKey = ks.getKey(KEY_ALIAS, null);
-        if (privateKey == null) {
+        // see:
+        // https://stackoverflow.com/questions/36488219/android-security-keystoreexception-invalid-key-blob
+        KeyStore.Entry entry = null;
+        try {
+            entry = ks.getEntry(KEY_ALIAS, null);
+        } catch (Exception e) {
+            e.printStackTrace();
+            ks.deleteEntry(KEY_ALIAS);
+        }
+        if (entry == null) {
             createKeys(context);
         }
     }
@@ -156,6 +164,7 @@ class RSACipher18Implementation {
             kpGenerator.initialize(spec);
             kpGenerator.generateKeyPair();
         } catch (StrongBoxUnavailableException se) {
+            se.printStackTrace();
             spec = new KeyGenParameterSpec.Builder(KEY_ALIAS, KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)
                     .setCertificateSubject(new X500Principal("CN=" + KEY_ALIAS))
                     .setDigests(KeyProperties.DIGEST_SHA256)


### PR DESCRIPTION
Fix  #58.
https://github.com/mogol/flutter_secure_storage/blob/6f57918a38af01f963245351ef0d8b5aa9272b6a/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipher18Implementation.java#L113

I had this issue in pixel3a(Android 9.0).
But, after I run fixed code once, #58 is no longer reproduced in the original code.
So, when an alias has never been created, `ks.getKey(KEY_ALIAS, null)` is expected to return NULL, but it maybe not.