### PR TITLE
Remove unnecessary manifest change

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.it_nomads.fluttersecurestorage">
-  <uses-sdk android:minSdkVersion="18" />
 </manifest>


### PR DESCRIPTION
Since its pointed out [here](https://github.com/mogol/flutter_secure_storage/blob/bb86847add89f93b0ca03ddff3a4ae8f06bda498/android/build.gradle#L29). It is not necessary to have it in the manifest. Also, seems to be breaking builds having it there.

Fixes https://github.com/mogol/flutter_secure_storage/issues/79 & https://github.com/mogol/flutter_secure_storage/issues/77