### PR TITLE
Support for specifying keychain accessibility options

### DIFF
--- a/lib/flutter_secure_storage.dart
+++ b/lib/flutter_secure_storage.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 
@@ -71,14 +72,39 @@ abstract class Options {
   }
 }
 
+// KeyChain accessibility attributes as defined here: 
+// https://developer.apple.com/documentation/security/ksecattraccessible?language=objc
+enum IOSAccessibility {
+  // The data in the keychain can only be accessed when the device is unlocked. 
+  // Only available if a passcode is set on the device.
+  // Items with this attribute do not migrate to a new device.
+  passcode,
+  
+  // The data in the keychain item can be accessed only while the device is unlocked by the user.
+  unlocked,
+  
+  // The data in the keychain item can be accessed only while the device is unlocked by the user.
+  // Items with this attribute do not migrate to a new device.
+  unlocked_this_device,
+
+  // The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by the user.
+  first_unlock, 
+  
+  // The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by the user.
+  // Items with this attribute do not migrate to a new device.
+  first_unlock_this_device, 
+}
+
 class IOSOptions extends Options {
-  IOSOptions({String groupId}) : _groupId = groupId;
+  IOSOptions({String groupId, IOSAccessibility accessibility = IOSAccessibility.unlocked}): 
+            _groupId = groupId,
+            _accessibility = accessibility;
 
   final String _groupId;
-
+  final IOSAccessibility _accessibility;
   @override
   Map<String, String> _toMap() {
-    return <String, String>{'groupId': _groupId};
+    return <String, String>{'groupId': _groupId, 'accessibility': describeEnum(_accessibility)};
   }
 }
 

--- a/lib/flutter_secure_storage.dart
+++ b/lib/flutter_secure_storage.dart
@@ -104,7 +104,14 @@ class IOSOptions extends Options {
   final IOSAccessibility _accessibility;
   @override
   Map<String, String> _toMap() {
-    return <String, String>{'groupId': _groupId, 'accessibility': describeEnum(_accessibility)};
+    final m = Map<String, String>();
+    if (_groupId != null) {
+      m['groupId'] = _groupId;
+    }
+    if (_accessibility != null) {
+      m['accessibility'] = describeEnum(_accessibility);
+    }
+    return m;
   }
 }
 


### PR DESCRIPTION
Adds support for specifying [Keychain Item Accessibility](https://developer.apple.com/documentation/security/keychain_services/keychain_items/restricting_keychain_item_accessibility?language=objc)

The options are specified as an enum value passed in the IOSOptions object as parameter to the `write` function.

This allows us to be able to fetch secure values while the app is backgrounded, by specifying [`first_unlock`](https://developer.apple.com/documentation/security/ksecattraccessibleafterfirstunlock?language=objc) or [`first_unlock_this_device`](https://developer.apple.com/documentation/security/ksecattraccessibleafterfirstunlockthisdeviceonly?language=objc). The default if not specified is [`unlocked`](https://developer.apple.com/documentation/security/ksecattraccessiblewhenunlocked?language=objc).


An example:
```
final options = IOSOptions(accessibility: IOSAccessibility.first_unlock);
await storage.write(key: key, value: value, iOptions: options);
```


resolves:
https://github.com/mogol/flutter_secure_storage/issues/50
https://github.com/mogol/flutter_secure_storage/issues/94