### PR TITLE
Fix for issue #116: Android hanging UI on StorageCipher initialization

### DIFF
--- a/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -3,6 +3,8 @@ package com.it_nomads.fluttersecurestorage;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Handler;
+import android.os.Looper;
 import android.util.Base64;
 import android.util.Log;
 import androidx.annotation.NonNull;
@@ -31,8 +33,10 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
     private StorageCipher storageCipher;
     private static final String ELEMENT_PREFERENCES_KEY_PREFIX = "VGhpcyBpcyB0aGUgcHJlZml4IGZvciBhIHNlY3VyZSBzdG9yYWdlCg";
     private static final String SHARED_PREFERENCES_NAME = "FlutterSecureStorage";
+    private static Context applicationContext;  //Necessary for deferred initialization of storageCipher
 
     public static void registerWith(Registrar registrar) {
+      applicationContext = registrar.context().getApplicationContext();
       FlutterSecureStoragePlugin instance = new FlutterSecureStoragePlugin();
       instance.initInstance(registrar.messenger(), registrar.context());
     }
@@ -43,13 +47,29 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
           charset = Charset.forName("UTF-8");
 
           StorageCipher18Implementation.moveSecretFromPreferencesIfNeeded(preferences, context);
-          storageCipher = new StorageCipher18Implementation(context);
 
           channel = new MethodChannel(messenger, "plugins.it_nomads.com/flutter_secure_storage");
           channel.setMethodCallHandler(this);
       } catch (Exception e) {
           Log.e("FlutterSecureStoragePl", "Registration failed", e);
       }
+    }
+
+    /**
+     * This must be run in a separate Thread from an async method to avoid hanging UI thread on
+     * live devices in release mode.
+     * The most convenient place for that appears to be onMethodCall().
+     */
+    private void ensureInitStorageCipher() {
+        if(storageCipher == null) {
+            try {
+                Log.i("FlutterSecureStoragePl", "Initializing StorageCipher");
+                storageCipher = new StorageCipher18Implementation(applicationContext);
+                Log.i("FlutterSecureStoragePl", "StorageCipher initialization complete");
+            } catch (Exception e) {
+                Log.e("FlutterSecureStoragePl", "StorageCipher initialization failed", e);
+            }
+        }
     }
 
     @Override
@@ -64,50 +84,9 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
     }
 
     @Override
-    public void onMethodCall(MethodCall call, Result result) {
-        try {
-            switch (call.method) {
-                case "write": {
-                    String key = getKeyFromCall(call);
-                    Map arguments = (Map) call.arguments;
-
-                    String value = (String) arguments.get("value");
-                    write(key, value);
-                    result.success(null);
-                    break;
-                }
-                case "read": {
-                    String key = getKeyFromCall(call);
-
-                    String value = read(key);
-                    result.success(value);
-                    break;
-                }
-                case "readAll": {
-                    Map<String, String> value = readAll();
-                    result.success(value);
-                    break;
-                }
-                case "delete": {
-                    String key = getKeyFromCall(call);
-
-                    delete(key);
-                    result.success(null);
-                    break;
-                }
-                case "deleteAll": {
-                    deleteAll();
-                    result.success(null);
-                    break;
-                }
-                default:
-                    result.notImplemented();
-                    break;
-            }
-
-        } catch (Exception e) {
-            result.error("Exception encountered", call.method, e);
-        }
+    public void onMethodCall(@NonNull MethodCall call, @NonNull Result rawResult) {
+        MethodResultWrapper result = new MethodResultWrapper(rawResult);
+        new Thread(new MethodRunner(call, result)).start();
     }
 
     private String getKeyFromCall(MethodCall call) {
@@ -172,5 +151,109 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
         byte[] result = storageCipher.decrypt(data);
 
         return new String(result, charset);
+    }
+
+    /**
+     * Wraps the functionality of onMethodCall() in a Runnable for execution in a new Thread.
+     */
+    class MethodRunner implements Runnable {
+        private final MethodCall call;
+        private final Result result;
+
+        MethodRunner(MethodCall call, Result result) {
+            this.call = call;
+            this.result = result;
+        }
+
+        @Override
+        public void run() {
+            try {
+                ensureInitStorageCipher();
+                switch (call.method) {
+                    case "write": {
+                        String key = getKeyFromCall(call);
+                        Map arguments = (Map) call.arguments;
+
+                        String value = (String) arguments.get("value");
+                        write(key, value);
+                        result.success(null);
+                        break;
+                    }
+                    case "read": {
+                        String key = getKeyFromCall(call);
+
+                        String value = read(key);
+                        result.success(value);
+                        break;
+                    }
+                    case "readAll": {
+                        Map<String, String> value = readAll();
+                        result.success(value);
+                        break;
+                    }
+                    case "delete": {
+                        String key = getKeyFromCall(call);
+
+                        delete(key);
+                        result.success(null);
+                        break;
+                    }
+                    case "deleteAll": {
+                        deleteAll();
+                        result.success(null);
+                        break;
+                    }
+                    default:
+                        result.notImplemented();
+                        break;
+                }
+
+            } catch (Exception e) {
+                result.error("Exception encountered", call.method, e);
+            }
+        }
+    }
+
+    /**
+     * MethodChannel.Result wrapper that responds on the platform thread.
+     */
+    class MethodResultWrapper implements Result {
+
+        private Result methodResult;
+        private final Handler handler = new Handler(Looper.getMainLooper());
+
+        MethodResultWrapper(Result methodResult) {
+            this.methodResult = methodResult;
+        }
+
+        @Override
+        public void success(final Object result) {
+            handler.post(new Runnable() {
+                @Override
+                public void run() {
+                    methodResult.success(result);
+                }
+            });
+        }
+
+        @Override
+        public void error(final String errorCode, final String errorMessage, final Object errorDetails) {
+            handler.post(new Runnable() {
+                @Override
+                public void run() {
+                    methodResult.error(errorCode, errorMessage, errorDetails);
+                }
+            });
+        }
+
+        @Override
+        public void notImplemented() {
+            handler.post(new Runnable() {
+                @Override
+                public void run() {
+                    methodResult.notImplemented();
+                }
+            });
+        }
     }
 }

--- a/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -61,13 +61,17 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
      * The most convenient place for that appears to be onMethodCall().
      */
     private void ensureInitStorageCipher() {
-        if(storageCipher == null) {
-            try {
-                Log.i("FlutterSecureStoragePl", "Initializing StorageCipher");
-                storageCipher = new StorageCipher18Implementation(applicationContext);
-                Log.i("FlutterSecureStoragePl", "StorageCipher initialization complete");
-            } catch (Exception e) {
-                Log.e("FlutterSecureStoragePl", "StorageCipher initialization failed", e);
+        if(storageCipher == null) { //Check to avoid unnecessary entry into syncronized block
+            synchronized (this) {
+                if(storageCipher == null) { //Check inside sync block to avoid race condition.
+                    try {
+                        Log.d("FlutterSecureStoragePl", "Initializing StorageCipher");
+                        storageCipher = new StorageCipher18Implementation(applicationContext);
+                        Log.d("FlutterSecureStoragePl", "StorageCipher initialization complete");
+                    } catch (Exception e) {
+                        Log.e("FlutterSecureStoragePl", "StorageCipher initialization failed", e);
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Fix for issue #116: Android hanging UI on StorageCipher initialization. 
Similar issue may or may not affect iOS.
Basic architecture example taken from https://github.com/flutter/flutter/issues/22024#issuecomment-479849362

This fixes the issue by deferring StorageCipher initialization until a channel method is invoked, and completing the initialization and channel method in a separate Thread that returns the result through an asynchronous wrapper.