### PR TITLE
Make MethodResultWrapper static and methodResult final

### DIFF
--- a/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -220,9 +220,9 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
     /**
      * MethodChannel.Result wrapper that responds on the platform thread.
      */
-    class MethodResultWrapper implements Result {
+    static class MethodResultWrapper implements Result {
 
-        private Result methodResult;
+        private final Result methodResult;
         private final Handler handler = new Handler(Looper.getMainLooper());
 
         MethodResultWrapper(Result methodResult) {


### PR DESCRIPTION
MethodResultWrapper does not reference the enclosing class and, therefore, can be static.

methodResult is only assigned during initialization and, therefore, can be final.