### PR TITLE
Fix RSACipher18Implementation bug on startup at API level 19 and lower

### DIFF
--- a/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipher18Implementation.java
+++ b/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipher18Implementation.java
@@ -132,7 +132,6 @@ class RSACipher18Implementation {
         resources.updateConfiguration(config, resources.getDisplayMetrics());
     }
 
-    @SuppressLint("NewApi")
     private void createKeys(Context context) throws Exception {
         Log.i("fluttersecurestorage", "Creating keys!");
         final Locale localeBeforeFakingEnglishLocale = Locale.getDefault();
@@ -170,23 +169,28 @@ class RSACipher18Implementation {
 
                 spec = builder.build();
             }
+
             try {
                 Log.i("fluttersecurestorage", "Initializing");
                 kpGenerator.initialize(spec);
                 Log.i("fluttersecurestorage", "Generating key pair");
                 kpGenerator.generateKeyPair();
-            } catch (StrongBoxUnavailableException se) {
-                spec = new KeyGenParameterSpec.Builder(KEY_ALIAS, KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)
-                        .setCertificateSubject(new X500Principal("CN=" + KEY_ALIAS))
-                        .setDigests(KeyProperties.DIGEST_SHA256)
-                        .setBlockModes(KeyProperties.BLOCK_MODE_ECB)
-                        .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
-                        .setCertificateSerialNumber(BigInteger.valueOf(1))
-                        .setCertificateNotBefore(start.getTime())
-                        .setCertificateNotAfter(end.getTime())
-                        .build();
-                kpGenerator.initialize(spec);
-                kpGenerator.generateKeyPair();
+            } catch (Exception e) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    if (e instanceof StrongBoxUnavailableException) {
+                        spec = new KeyGenParameterSpec.Builder(KEY_ALIAS, KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)
+                                .setCertificateSubject(new X500Principal("CN=" + KEY_ALIAS))
+                                .setDigests(KeyProperties.DIGEST_SHA256)
+                                .setBlockModes(KeyProperties.BLOCK_MODE_ECB)
+                                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
+                                .setCertificateSerialNumber(BigInteger.valueOf(1))
+                                .setCertificateNotBefore(start.getTime())
+                                .setCertificateNotAfter(end.getTime())
+                                .build();
+                        kpGenerator.initialize(spec);
+                        kpGenerator.generateKeyPair();
+                    }
+                }
             }
         } finally {
             setLocale(localeBeforeFakingEnglishLocale);


### PR DESCRIPTION
Fix app crash on Startup at Android 4.3 (api 18) and 4.4 (api 19).

The api level conditions are all correct, but because of the suppress lint annotation, the catch block with StrongBoxUnavailableException alert was suppressed and that code causes some kind of build optimization bug.

This fix the issue #52