### PR TITLE
Make it possible to have no iOS account name(kSecAttrService)

### DIFF
--- a/ios/Classes/FlutterSecureStoragePlugin.m
+++ b/ios/Classes/FlutterSecureStoragePlugin.m
@@ -38,7 +38,7 @@ static NSString *const InvalidParameters = @"Invalid parameter's type";
     if ([@"read" isEqualToString:call.method]) {
         NSString *key = arguments[@"key"];
         NSString *groupId = options[@"groupId"];
-        BOOL *useAccountName = [options[@"useFlutterSecureStorageServiceAsAccountName"] isEqualToString: "true"];
+        BOOL *useAccountName = [options[@"useFlutterSecureStorageServiceAsAccountName"] isEqualToString: @"true"];
         NSString *value = [self read:key forGroup:groupId useAccountNameAttr:useAccountName];
         
         result(value);
@@ -47,7 +47,7 @@ static NSString *const InvalidParameters = @"Invalid parameter's type";
         NSString *key = arguments[@"key"];
         NSString *value = arguments[@"value"];
         NSString *groupId = options[@"groupId"];
-        BOOL *useAccountName = [options[@"useFlutterSecureStorageServiceAsAccountName"] isEqualToString: "true"];
+        BOOL *useAccountName = [options[@"useFlutterSecureStorageServiceAsAccountName"] isEqualToString: @"true"];
         NSString *accessibility = options[@"accessibility"];
         if (![value isKindOfClass:[NSString class]]){
             result(InvalidParameters);
@@ -60,19 +60,19 @@ static NSString *const InvalidParameters = @"Invalid parameter's type";
     } else if ([@"delete" isEqualToString:call.method]) {
         NSString *key = arguments[@"key"];
         NSString *groupId = options[@"groupId"];
-        BOOL *useAccountName = [options[@"useFlutterSecureStorageServiceAsAccountName"] isEqualToString: "true"];
+        BOOL *useAccountName = [options[@"useFlutterSecureStorageServiceAsAccountName"] isEqualToString: @"true"];
         [self delete:key forGroup:groupId useAccountNameAttr:useAccountName];
         
         result(nil);
     } else if ([@"deleteAll" isEqualToString:call.method]) {
         NSString *groupId = options[@"groupId"];
-        BOOL *useAccountName = [options[@"useFlutterSecureStorageServiceAsAccountName"] isEqualToString: "true"];
+        BOOL *useAccountName = [options[@"useFlutterSecureStorageServiceAsAccountName"] isEqualToString: @"true"];
         [self deleteAll: groupId useAccountNameAttr:useAccountName];
         
         result(nil);
     } else if ([@"readAll" isEqualToString:call.method]) {
         NSString *groupId = options[@"groupId"];
-        BOOL *useAccountName = [options[@"useFlutterSecureStorageServiceAsAccountName"] isEqualToString: "true"];
+        BOOL *useAccountName = [options[@"useFlutterSecureStorageServiceAsAccountName"] isEqualToString: @"true"];
         NSDictionary *value = [self readAll: groupId useAccountNameAttr:useAccountName];
 
         result(value);
@@ -89,7 +89,7 @@ static NSString *const InvalidParameters = @"Invalid parameter's type";
     if(useAccountName) {
         search[(__bridge id)kSecAttrService] = KEYCHAIN_SERVICE;
     }
-    
+
     search[(__bridge id)kSecAttrAccount] = key;
     search[(__bridge id)kSecMatchLimit] = (__bridge id)kSecMatchLimitOne;
     

--- a/ios/Classes/FlutterSecureStoragePlugin.m
+++ b/ios/Classes/FlutterSecureStoragePlugin.m
@@ -18,7 +18,6 @@ static NSString *const InvalidParameters = @"Invalid parameter's type";
     if (self){
         self.query = @{
                        (__bridge id)kSecClass :(__bridge id)kSecClassGenericPassword,
-                       (__bridge id)kSecAttrService :KEYCHAIN_SERVICE,
                        };
     }
     return self;

--- a/lib/flutter_secure_storage.dart
+++ b/lib/flutter_secure_storage.dart
@@ -4,11 +4,13 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 
+
 class FlutterSecureStorage {
   const FlutterSecureStorage();
 
   static const MethodChannel _channel =
       const MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+  static const IOSOptions _defaultIOSOptions = IOSOptions();
 
   /// Encrypts and saves the [key] with the given [value].
   ///
@@ -22,7 +24,7 @@ class FlutterSecureStorage {
   Future<void> write(
           {@required String key,
           @required String value,
-          IOSOptions iOptions,
+          IOSOptions iOptions = _defaultIOSOptions,
           AndroidOptions aOptions}) =>
       value != null
           ? _channel.invokeMethod('write', <String, dynamic>{
@@ -40,7 +42,7 @@ class FlutterSecureStorage {
   /// Can throw a [PlatformException].
   Future<String> read(
       {@required String key,
-      IOSOptions iOptions,
+      IOSOptions iOptions = _defaultIOSOptions,
       AndroidOptions aOptions}) async {
     final String value = await _channel.invokeMethod('read', <String, dynamic>{
       'key': key,
@@ -57,7 +59,7 @@ class FlutterSecureStorage {
   /// Can throw a [PlatformException].
   Future<bool> containsKey(
       {@required String key,
-      IOSOptions iOptions,
+      IOSOptions iOptions = _defaultIOSOptions,
       AndroidOptions aOptions}) async {
     final String value =
         await read(key: key, iOptions: iOptions, aOptions: aOptions);
@@ -72,7 +74,7 @@ class FlutterSecureStorage {
   /// Can throw a [PlatformException].
   Future<void> delete(
           {@required String key,
-          IOSOptions iOptions,
+          IOSOptions iOptions = _defaultIOSOptions,
           AndroidOptions aOptions}) =>
       _channel.invokeMethod('delete', <String, dynamic>{
         'key': key,
@@ -85,7 +87,7 @@ class FlutterSecureStorage {
   /// [aOptions] optional Android options
   /// Can throw a [PlatformException].
   Future<Map<String, String>> readAll(
-      {IOSOptions iOptions, AndroidOptions aOptions}) async {
+      {IOSOptions iOptions = _defaultIOSOptions, AndroidOptions aOptions}) async {
     final Map results = await _channel.invokeMethod('readAll',
         <String, dynamic>{'options': _selectOptions(iOptions, aOptions)});
     return results.cast<String, String>();
@@ -96,7 +98,7 @@ class FlutterSecureStorage {
   /// [iOptions] optional iOS options
   /// [aOptions] optional Android options
   /// Can throw a [PlatformException].
-  Future<void> deleteAll({IOSOptions iOptions, AndroidOptions aOptions}) =>
+  Future<void> deleteAll({IOSOptions iOptions = _defaultIOSOptions, AndroidOptions aOptions}) =>
       _channel.invokeMethod('deleteAll',
           <String, dynamic>{'options': _selectOptions(iOptions, aOptions)});
 
@@ -108,6 +110,8 @@ class FlutterSecureStorage {
 }
 
 abstract class Options {
+  const Options();
+
   Map<String, String> get params => _toMap();
 
   Map<String, String> _toMap() {
@@ -139,7 +143,7 @@ enum IOSAccessibility {
 }
 
 class IOSOptions extends Options {
-  IOSOptions(
+  const IOSOptions(
       {String groupId,
       IOSAccessibility accessibility = IOSAccessibility.unlocked,
       String accountName = 'flutter_secure_storage_service',

--- a/lib/flutter_secure_storage.dart
+++ b/lib/flutter_secure_storage.dart
@@ -142,15 +142,15 @@ class IOSOptions extends Options {
   IOSOptions(
       {String groupId,
       IOSAccessibility accessibility = IOSAccessibility.unlocked,
-      bool useFlutterSecureStorageServiceAsAccountName = true,
+      String accountName = 'flutter_secure_storage_service',
       })
       : _groupId = groupId,
         _accessibility = accessibility,
-        _useFlutterSecureStorageServiceAsAccountName = useFlutterSecureStorageServiceAsAccountName;
+        _accountName = accountName;
 
   final String _groupId;
   final IOSAccessibility _accessibility;
-  final bool _useFlutterSecureStorageServiceAsAccountName;
+  final String _accountName;
   @override
   Map<String, String> _toMap() {
     final m = <String, String>{};
@@ -160,7 +160,9 @@ class IOSOptions extends Options {
     if (_accessibility != null) {
       m['accessibility'] = describeEnum(_accessibility);
     }
-    m['useFlutterSecureStorageServiceAsAccountName'] = _useFlutterSecureStorageServiceAsAccountName.toString();
+    if (_accountName != null) {
+      m['accountName'] = _accountName;
+    }
 
     return m;
   }

--- a/lib/flutter_secure_storage.dart
+++ b/lib/flutter_secure_storage.dart
@@ -141,12 +141,16 @@ enum IOSAccessibility {
 class IOSOptions extends Options {
   IOSOptions(
       {String groupId,
-      IOSAccessibility accessibility = IOSAccessibility.unlocked})
+      IOSAccessibility accessibility = IOSAccessibility.unlocked,
+      bool useFlutterSecureStorageServiceAsAccountName = true,
+      })
       : _groupId = groupId,
-        _accessibility = accessibility;
+        _accessibility = accessibility,
+        _useFlutterSecureStorageServiceAsAccountName = useFlutterSecureStorageServiceAsAccountName;
 
   final String _groupId;
   final IOSAccessibility _accessibility;
+  final bool _useFlutterSecureStorageServiceAsAccountName;
   @override
   Map<String, String> _toMap() {
     final m = <String, String>{};
@@ -156,6 +160,8 @@ class IOSOptions extends Options {
     if (_accessibility != null) {
       m['accessibility'] = describeEnum(_accessibility);
     }
+    m['useFlutterSecureStorageServiceAsAccountName'] = _useFlutterSecureStorageServiceAsAccountName.toString();
+
     return m;
   }
 }


### PR DESCRIPTION
Problem:
Apps migrating from Native to Flutter might be using the SimpleKeychain library or something similar, that uses no account name (kSecAttrService). For such apps it is not possible to share KeyChain with Flutter using this package.


Proposed Solution: 
Make it possible to have no iOS account name(kSecAttrService). Having "flutter_secure_storage_service" as account name is still the default.
