### PR TITLE
Removed the Strongbox support as it turns out to be unstable.

### DIFF
--- a/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipher18Implementation.java
+++ b/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipher18Implementation.java
@@ -165,7 +165,6 @@ class RSACipher18Implementation {
 
     @SuppressLint("NewApi")
     private void createKeys(Context context) throws Exception {
-        Log.i("fluttersecurestorage", "Creating keys!");
         final Locale localeBeforeFakingEnglishLocale = Locale.getDefault();
         try {
             setLocale(Locale.ENGLISH);
@@ -191,10 +190,8 @@ class RSACipher18Implementation {
 
                 spec = builder.build();
             }
-            
-            Log.i("fluttersecurestorage", "Initializing");
+
             kpGenerator.initialize(spec);
-            Log.i("fluttersecurestorage", "Generating key pair");
             kpGenerator.generateKeyPair();
         } finally {
             setLocale(localeBeforeFakingEnglishLocale);

--- a/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipher18Implementation.java
+++ b/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipher18Implementation.java
@@ -131,29 +131,29 @@ class RSACipher18Implementation {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
             setSystemLocale(config, locale);
             context = context.createConfigurationContext(config);
-        }else{
+        } else {
             setSystemLocaleLegacy(config, locale);
             setContextConfigurationLegacy(context, config);
         }
     }
 
     @SuppressWarnings("deprecation")
-    private void setContextConfigurationLegacy(Context context, Configuration config){
+    private void setContextConfigurationLegacy(Context context, Configuration config) {
         context.getResources().updateConfiguration(config, context.getResources().getDisplayMetrics());
     }
 
     @SuppressWarnings("deprecation")
-    private void setSystemLocaleLegacy(Configuration config, Locale locale){
+    private void setSystemLocaleLegacy(Configuration config, Locale locale) {
         config.locale = locale;
     }
 
     @TargetApi(Build.VERSION_CODES.N)
-    private void setSystemLocale(Configuration config, Locale locale){
+    private void setSystemLocale(Configuration config, Locale locale) {
         config.setLocale(locale);
     }
 
     @SuppressWarnings("deprecation")
-    private AlgorithmParameterSpec makeAlgorithmParameterSpecLegacy(Context context, Calendar start, Calendar end){
+    private AlgorithmParameterSpec makeAlgorithmParameterSpecLegacy(Context context, Calendar start, Calendar end) {
         return new android.security.KeyPairGeneratorSpec.Builder(context)
                 .setAlias(KEY_ALIAS)
                 .setSubject(new X500Principal("CN=" + KEY_ALIAS))
@@ -189,30 +189,13 @@ class RSACipher18Implementation {
                         .setCertificateNotBefore(start.getTime())
                         .setCertificateNotAfter(end.getTime());
 
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                    builder.setIsStrongBoxBacked(true);
-                }
-
                 spec = builder.build();
             }
-            try {
-                Log.i("fluttersecurestorage", "Initializing");
-                kpGenerator.initialize(spec);
-                Log.i("fluttersecurestorage", "Generating key pair");
-                kpGenerator.generateKeyPair();
-            } catch (StrongBoxUnavailableException se) {
-                spec = new KeyGenParameterSpec.Builder(KEY_ALIAS, KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)
-                        .setCertificateSubject(new X500Principal("CN=" + KEY_ALIAS))
-                        .setDigests(KeyProperties.DIGEST_SHA256)
-                        .setBlockModes(KeyProperties.BLOCK_MODE_ECB)
-                        .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
-                        .setCertificateSerialNumber(BigInteger.valueOf(1))
-                        .setCertificateNotBefore(start.getTime())
-                        .setCertificateNotAfter(end.getTime())
-                        .build();
-                kpGenerator.initialize(spec);
-                kpGenerator.generateKeyPair();
-            }
+            
+            Log.i("fluttersecurestorage", "Initializing");
+            kpGenerator.initialize(spec);
+            Log.i("fluttersecurestorage", "Generating key pair");
+            kpGenerator.generateKeyPair();
         } finally {
             setLocale(localeBeforeFakingEnglishLocale);
         }


### PR DESCRIPTION
We are expeciencing crashes on mostly pixel devices (~10k users).

The stacktraces strongly relate to the following issues: https://github.com/mogol/flutter_secure_storage/issues/161 https://github.com/mogol/flutter_secure_storage/issues/206

After quite some investigating, it seems related to strongbox which apparently is quite unstable:
https://github.com/beemdevelopment/Aegis/issues/87
https://alexbakker.me/post/mysterious-google-titan-m-bug-cve-2019-9465.html

And this comment reflects on this: https://github.com/mogol/flutter_secure_storage/issues/161#issuecomment-769829680

So hereby the proposal to remove strongbox support.