### PR TITLE
#203 encrypted shared preferences

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,16 +22,20 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 18
-        targetSdkVersion 28
+        targetSdkVersion 30
         versionCode 6
         versionName "3.3.1"
     }
     lintOptions {
         disable 'InvalidPackage'
     }
+}
+
+dependencies {
+    implementation "androidx.security:security-crypto:1.1.0-alpha03"
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.it_nomads.fluttersecurestorage">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.it_nomads.fluttersecurestorage">
+
+    <uses-sdk tools:overrideLibrary="androidx.security"/>
 </manifest>

--- a/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -195,7 +195,7 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
     private void delete(String key) {
         SharedPreferences.Editor editor = preferences.edit();
         editor.remove(key);
-        editor.apply();
+        editor.commit();
     }
 
     private String addPrefixToKey(String key) {

--- a/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -150,17 +150,18 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
         @SuppressWarnings("unchecked")
         Map<String, String> raw = (Map<String, String>) preferences.getAll();
 
-        if(useEncryptedSharedPreference){
-            return raw;
-        }
-
         Map<String, String> all = new HashMap<>();
         for (Map.Entry<String, String> entry : raw.entrySet()) {
             String key = entry.getKey().replaceFirst(ELEMENT_PREFERENCES_KEY_PREFIX + '_', "");
-            String rawValue = entry.getValue();
-            String value = decodeRawValue(rawValue);
 
-            all.put(key, value);
+            if (useEncryptedSharedPreference) {
+                all.put(key, entry.getValue());
+            } else {
+                String rawValue = entry.getValue();
+                String value = decodeRawValue(rawValue);
+
+                all.put(key, value);
+            }
         }
         return all;
     }

--- a/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -147,7 +147,6 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
     }
 
     private Map<String, String> readAll(boolean useEncryptedSharedPreference) throws Exception {
-        @SuppressWarnings("unchecked")
         Map<String, String> raw = (Map<String, String>) preferences.getAll();
 
         Map<String, String> all = new HashMap<>();
@@ -195,14 +194,7 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
 
     private void delete(String key) {
         SharedPreferences.Editor editor = preferences.edit();
-
-//        if (useEncryptedSharedPreference) {
-            editor.remove(key);
-//        } else {
-//            editor.remove(key);
-//        }
-
-
+        editor.remove(key);
         editor.apply();
     }
 

--- a/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -3,18 +3,27 @@ package com.it_nomads.fluttersecurestorage;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.os.Looper;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
 import android.util.Base64;
 import android.util.Log;
+
+import androidx.annotation.RequiresApi;
+import androidx.security.crypto.EncryptedSharedPreferences;
+import androidx.security.crypto.MasterKey;
 
 import com.it_nomads.fluttersecurestorage.ciphers.StorageCipher;
 import com.it_nomads.fluttersecurestorage.ciphers.StorageCipher18Implementation;
 
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
+import java.security.GeneralSecurityException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -67,7 +76,19 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
       }
     }
 
-    private void ensureInitStorageCipher() {
+    private void ensureInitialized(Map arguments) {
+
+        if(useEncryptedSharedPreferences((Map) arguments.get("options")) &&
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.M){
+            if(!(preferences instanceof  EncryptedSharedPreferences)){
+                try {
+                    preferences = createEncryptedSharedPreferences(applicationContext);
+                } catch (Exception e){
+                    Log.e("FlutterSecureStoragePl", "EncryptedSharedPreferences initialization failed", e);
+                }
+            }
+        }
+
         if (storageCipher == null) {
             try {
                 storageCipher = new StorageCipher18Implementation(applicationContext);
@@ -75,6 +96,24 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                 Log.e(TAG, "StorageCipher initialization failed", e);
             }
         }
+    }
+
+    private boolean useEncryptedSharedPreferences(Map arguments) {
+        return arguments.containsKey("encryptedSharedPreferences") && arguments.get("encryptedSharedPreferences").equals("true");
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    private SharedPreferences createEncryptedSharedPreferences(Context context) throws GeneralSecurityException, IOException {
+        MasterKey key = new MasterKey.Builder(context)
+                .setKeyGenParameterSpec(
+                        new KeyGenParameterSpec
+                                .Builder(MasterKey.DEFAULT_MASTER_KEY_ALIAS, KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+                                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+                                .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+                                .setKeySize(256).build())
+                .build();
+        return EncryptedSharedPreferences.create(context, SHARED_PREFERENCES_NAME, key, EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM);
     }
 
     @Override
@@ -107,9 +146,13 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
         return key;
     }
 
-    private Map<String, String> readAll() throws Exception {
+    private Map<String, String> readAll(boolean useEncryptedSharedPreference) throws Exception {
         @SuppressWarnings("unchecked")
         Map<String, String> raw = (Map<String, String>) preferences.getAll();
+
+        if(useEncryptedSharedPreference){
+            return raw;
+        }
 
         Map<String, String> all = new HashMap<>();
         for (Map.Entry<String, String> entry : raw.entrySet()) {
@@ -129,25 +172,37 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
         editor.commit();
     }
 
-    private void write(String key, String value) throws Exception {
+    private void write(String key, String value, boolean useEncryptedSharedPreference) throws Exception {
         byte[] result = storageCipher.encrypt(value.getBytes(charset));
         SharedPreferences.Editor editor = preferences.edit();
 
-        editor.putString(key, Base64.encodeToString(result, 0));
+        if(useEncryptedSharedPreference){
+            editor.putString(key, value);
+        } else {
+            editor.putString(key, Base64.encodeToString(result, 0));
+        }
         editor.commit();
     }
 
-    private String read(String key) throws Exception {
-        String encoded = preferences.getString(key, null);
-
-        return decodeRawValue(encoded);
+    private String read(String key, boolean useEncryptedSharedPreference) throws Exception {
+        String rawValue = preferences.getString(key, null);
+        if(useEncryptedSharedPreference){
+            return rawValue;
+        }
+        return decodeRawValue(rawValue);
     }
 
     private void delete(String key) {
         SharedPreferences.Editor editor = preferences.edit();
 
-        editor.remove(key);
-        editor.commit();
+//        if (useEncryptedSharedPreference) {
+            editor.remove(key);
+//        } else {
+//            editor.remove(key);
+//        }
+
+
+        editor.apply();
     }
 
     private String addPrefixToKey(String key) {
@@ -181,23 +236,25 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
             try {
                 switch (call.method) {
                     case "write": {
-                        ensureInitStorageCipher();
-
                         String key = getKeyFromCall(call);
                         Map arguments = (Map) call.arguments;
 
+                        ensureInitialized(arguments);
+
                         String value = (String) arguments.get("value");
-                        write(key, value);
+                        boolean useEncryptedSharedPreference = useEncryptedSharedPreferences((Map) arguments.get("options"));
+                        write(key, value, useEncryptedSharedPreference);
                         result.success(null);
                         break;
                     }
                     case "read": {
                         String key = getKeyFromCall(call);
+                        Map arguments = (Map) call.arguments;
 
                         if (preferences.contains(key)) {
-                            ensureInitStorageCipher();
-
-                            String value = read(key);
+                            ensureInitialized(arguments);
+                            boolean useEncryptedSharedPreference = useEncryptedSharedPreferences((Map) arguments.get("options"));
+                            String value = read(key, useEncryptedSharedPreference);
                             result.success(value);
                         } else {
                             result.success(null);
@@ -205,9 +262,12 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                         break;
                     }
                     case "readAll": {
-                        ensureInitStorageCipher();
+                        Map arguments = (Map) call.arguments;
 
-                        Map<String, String> value = readAll();
+                        ensureInitialized(arguments);
+                        boolean useEncryptedSharedPreference = useEncryptedSharedPreferences((Map) arguments.get("options"));
+
+                        Map<String, String> value = readAll(useEncryptedSharedPreference);
                         result.success(value);
                         break;
                     }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,6 +35,7 @@ class _ItemsWidgetState extends State<ItemsWidget> {
   Future<Null> _readAll() async {
     final all = await _storage.readAll(
       iOptions: _getIOSOptions(),
+      aOptions: _getAndroidOptions()
     );
     setState(() {
       _items = all.entries
@@ -46,6 +47,7 @@ class _ItemsWidgetState extends State<ItemsWidget> {
   void _deleteAll() async {
     await _storage.deleteAll(
       iOptions: _getIOSOptions(),
+      aOptions: _getAndroidOptions()
     );
     _readAll();
   }
@@ -58,6 +60,7 @@ class _ItemsWidgetState extends State<ItemsWidget> {
       key: key,
       value: value,
       iOptions: _getIOSOptions(),
+      aOptions: _getAndroidOptions()
     );
     _readAll();
   }
@@ -65,6 +68,10 @@ class _ItemsWidgetState extends State<ItemsWidget> {
   IOSOptions _getIOSOptions() => IOSOptions(
         accountName: _getAccountName(),
       );
+
+  AndroidOptions _getAndroidOptions() => AndroidOptions(
+    encryptedSharedPreferences: true,
+  );
 
   String? _getAccountName() =>
       _accountNameController.text.isEmpty ? null : _accountNameController.text;
@@ -153,6 +160,7 @@ class _ItemsWidgetState extends State<ItemsWidget> {
         await _storage.delete(
           key: item.key,
           iOptions: _getIOSOptions(),
+          aOptions: _getAndroidOptions()
         );
         _readAll();
 
@@ -166,6 +174,7 @@ class _ItemsWidgetState extends State<ItemsWidget> {
             key: item.key,
             value: result,
             iOptions: _getIOSOptions(),
+              aOptions: _getAndroidOptions()
           );
           _readAll();
         }

--- a/lib/flutter_secure_storage.dart
+++ b/lib/flutter_secure_storage.dart
@@ -209,8 +209,23 @@ class IOSOptions extends Options {
 }
 
 class AndroidOptions extends Options {
+  AndroidOptions({bool encryptedSharedPreferences = false})
+      : _encryptedSharedPreferences = encryptedSharedPreferences;
+
+  final bool _encryptedSharedPreferences;
+
   @override
-  Map<String, String> _toMap() => <String, String>{};
+  Map<String, String> _toMap() => <String, String>{
+        'encryptedSharedPreferences': '$_encryptedSharedPreferences'
+      };
+
+  AndroidOptions copyWith({
+    bool? encryptedSharedPreferences,
+  }) =>
+      AndroidOptions(
+        encryptedSharedPreferences:
+            encryptedSharedPreferences ?? _encryptedSharedPreferences,
+      );
 }
 
 class LinuxOptions extends Options {

--- a/lib/flutter_secure_storage.dart
+++ b/lib/flutter_secure_storage.dart
@@ -212,6 +212,7 @@ class AndroidOptions extends Options {
   AndroidOptions({bool encryptedSharedPreferences = false})
       : _encryptedSharedPreferences = encryptedSharedPreferences;
 
+  /// EncryptedSharedPrefences are only available on API 23 and greater
   final bool _encryptedSharedPreferences;
 
   @override


### PR DESCRIPTION
Based on #204 i've implemented optional encryptedSharedPreference. Below API 23 it will fallback to the 'normal' shared preferences.

This can be enabled by setting the following options:
```dart
  AndroidOptions _getAndroidOptions() => AndroidOptions(
    encryptedSharedPreferences: true,
  );
```