### PR TITLE
[windows] Make credential key unique to the app

### DIFF
--- a/flutter_secure_storage/example/pubspec.yaml
+++ b/flutter_secure_storage/example/pubspec.yaml
@@ -26,3 +26,15 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+
+dependency_overrides:
+  flutter_secure_storage_platform_interface:
+    path: ../../flutter_secure_storage_platform_interface
+  flutter_secure_storage_linux:
+    path: ../../flutter_secure_storage_linux
+  flutter_secure_storage_macos:
+    path: ../../flutter_secure_storage_macos
+  flutter_secure_storage_web:
+    path: ../../flutter_secure_storage_web
+  flutter_secure_storage_windows:
+    path: ../../flutter_secure_storage_windows

--- a/flutter_secure_storage_windows/windows/CMakeLists.txt
+++ b/flutter_secure_storage_windows/windows/CMakeLists.txt
@@ -22,3 +22,5 @@ set(flutter_secure_storage_bundled_libraries
   ""
   PARENT_SCOPE
 )
+
+add_compile_definitions(SECURE_STORAGE_KEY="${BINARY_NAME}")

--- a/flutter_secure_storage_windows/windows/CMakeLists.txt
+++ b/flutter_secure_storage_windows/windows/CMakeLists.txt
@@ -23,4 +23,4 @@ set(flutter_secure_storage_bundled_libraries
   PARENT_SCOPE
 )
 
-add_compile_definitions(SECURE_STORAGE_KEY="${BINARY_NAME}")
+add_compile_definitions(SECURE_STORAGE_KEY_PREFIX="${BINARY_NAME}_VGhpcyBpcyB0aGUgcHJlZml4IGZv_")

--- a/flutter_secure_storage_windows/windows/flutter_secure_storage_windows_plugin.cpp
+++ b/flutter_secure_storage_windows/windows/flutter_secure_storage_windows_plugin.cpp
@@ -65,8 +65,8 @@ namespace
     bool ContainsKey(const std::string &key);
   };
 
-  const std::string ELEMENT_PREFERENCES_KEY_PREFIX = "VGhpcyBpcyB0aGUgcHJlZml4IGZvciBhIHNlY3VyZSBzdG9yYWdlCg_";
-  const int ELEMENT_PREFERENCES_KEY_PREFIX_LENGTH = 55;
+  const std::string ELEMENT_PREFERENCES_KEY_PREFIX = SECURE_STORAGE_KEY "_VGhpcyBpcyB0aGUgcHJlZml4IGZv_";
+  const int ELEMENT_PREFERENCES_KEY_PREFIX_LENGTH = 30 + (sizeof SECURE_STORAGE_KEY) - 1;
 
   // this string is used to filter the credential storage so that only the values written
   // by this plugin shows up.

--- a/flutter_secure_storage_windows/windows/flutter_secure_storage_windows_plugin.cpp
+++ b/flutter_secure_storage_windows/windows/flutter_secure_storage_windows_plugin.cpp
@@ -65,8 +65,8 @@ namespace
     bool ContainsKey(const std::string &key);
   };
 
-  const std::string ELEMENT_PREFERENCES_KEY_PREFIX = SECURE_STORAGE_KEY "_VGhpcyBpcyB0aGUgcHJlZml4IGZv_";
-  const int ELEMENT_PREFERENCES_KEY_PREFIX_LENGTH = 30 + (sizeof SECURE_STORAGE_KEY) - 1;
+  const std::string ELEMENT_PREFERENCES_KEY_PREFIX = SECURE_STORAGE_KEY_PREFIX;
+  const int ELEMENT_PREFERENCES_KEY_PREFIX_LENGTH = (sizeof SECURE_STORAGE_KEY_PREFIX) - 1;
 
   // this string is used to filter the credential storage so that only the values written
   // by this plugin shows up.


### PR DESCRIPTION
Resolves issue #294 

I also added dependency overrides to the example app to simplify local plugin testing. Can be removed if not desired.