### PR TITLE
Android encryption migration

### DIFF
--- a/.github/workflows/flutter_drive.yml
+++ b/.github/workflows/flutter_drive.yml
@@ -5,7 +5,7 @@ jobs:
       runs-on: macos-latest
       strategy:
         matrix:
-          api-level: [31]
+          api-level: [30]
           target: [default]
       steps:
         - uses: actions/checkout@v2

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -119,6 +119,7 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
     }
 
     private boolean useEncryptedSharedPreferences(Map<String, Object> arguments) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return false;
         return arguments.containsKey("encryptedSharedPreferences") && arguments.get("encryptedSharedPreferences").equals("true");
     }
 

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipher18Implementation.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipher18Implementation.java
@@ -23,10 +23,10 @@ import javax.security.auth.x500.X500Principal;
 
 class RSACipher18Implementation {
 
-    private final String KEY_ALIAS;
     private static final String KEYSTORE_PROVIDER_ANDROID = "AndroidKeyStore";
     private static final String TYPE_RSA = "RSA";
-    private Context context;
+    private final String KEY_ALIAS;
+    private final Context context;
 
 
     public RSACipher18Implementation(Context context) throws Exception {

--- a/flutter_secure_storage/example/test_driver/app_test.dart
+++ b/flutter_secure_storage/example/test_driver/app_test.dart
@@ -31,11 +31,17 @@ void main() {
       await pageObject.editRow('Row 0', 0);
       await pageObject.editRow('Row 1', 1);
 
+      await Future.delayed(const Duration(seconds: 3));
+
       await pageObject.rowHasTitle('Row 0', 0);
       await pageObject.rowHasTitle('Row 1', 1);
 
+      await Future.delayed(const Duration(seconds: 3));
+
       await pageObject.deleteRow(1);
       await pageObject.hasNoRow(1);
+
+      await Future.delayed(const Duration(seconds: 3));
 
       await pageObject.rowHasTitle('Row 0', 0);
       await pageObject.deleteRow(0);


### PR DESCRIPTION
This PR probably fixes #161, #248, #278, #312

This PR enables the migration of data to encryptedSharedPreference when enabled.
This PR also adds some other checks to ensure initialization performs correctly.