### PR TITLE
Update the docs of FlutterSecureStorage.delete().

### DIFF
--- a/flutter_secure_storage/lib/flutter_secure_storage.dart
+++ b/flutter_secure_storage/lib/flutter_secure_storage.dart
@@ -121,6 +121,8 @@ class FlutterSecureStorage {
 
   /// Deletes associated value for the given [key].
   ///
+  /// If the given [key] does not exist, nothing will happen.
+  /// 
   /// [key] shouldn't be null.
   /// [iOptions] optional iOS options
   /// [aOptions] optional Android options


### PR DESCRIPTION
In some cases, the keys not existing will be given to the `FlutterSecureStorage.delete()` function.

In my opinion, it's better to make this scenario clear.