### PR TITLE
fix issue of memory leak

### DIFF
--- a/flutter_secure_storage/ios/Classes/FlutterSecureStoragePlugin.m
+++ b/flutter_secure_storage/ios/Classes/FlutterSecureStoragePlugin.m
@@ -170,7 +170,7 @@ static NSString *const InvalidParameters = @"Invalid parameter's type";
         NSData *data = (__bridge NSData*)resultData;
         value = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     }
-    
+    CFRelease(resultData);
     return value;
 }
 
@@ -253,7 +253,7 @@ static NSString *const InvalidParameters = @"Invalid parameter's type";
         }
         return [results copy];
     }
-    
+    CFRelease(resultData);
     return @{};
 }
 

--- a/flutter_secure_storage/ios/Classes/FlutterSecureStoragePlugin.m
+++ b/flutter_secure_storage/ios/Classes/FlutterSecureStoragePlugin.m
@@ -169,8 +169,8 @@ static NSString *const InvalidParameters = @"Invalid parameter's type";
     if (status == noErr){
         NSData *data = (__bridge NSData*)resultData;
         value = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
+        CFRelease(resultData);
     }
-    CFRelease(resultData);
     return value;
 }
 
@@ -251,9 +251,9 @@ static NSString *const InvalidParameters = @"Invalid parameter's type";
             NSString *value = [[NSString alloc] initWithData:item[(__bridge NSString *)kSecValueData] encoding:NSUTF8StringEncoding];
             results[key] = value;
         }
+        CFRelease(resultData);
         return [results copy];
     }
-    CFRelease(resultData);
     return @{};
 }
 


### PR DESCRIPTION
Hello author, first of all, thank you very much for providing this useful plugin. I'm having some memory leak issue while using this plugin. 
<img width="799" alt="image" src="https://user-images.githubusercontent.com/24282000/168740346-e08a13aa-8ad0-4580-9162-2a6820aa1a1c.png">
I use xcode's instrument and found that it is the problem of 'read()' and 'readAll()'. It looks like the cause of the memory leak is that the memory of the CFDataRef is not freed.
<img width="772" alt="image" src="https://user-images.githubusercontent.com/24282000/168751983-ac3eb455-10f4-4b34-b0ed-fc3644733942.png">
After I released the memory of CFDataRef and tested it, there was no memory leak issue.
<img width="1012" alt="image" src="https://user-images.githubusercontent.com/24282000/168751789-35c162f2-3812-4dd0-ad1f-2b05c7077f3f.png">
Thank you for reviewing my PR and to find better solutions. Hopefully a new plugin version can be released to solve my memory leak issue.