### PR TITLE
Feature/android modern algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,26 @@ flutter_secure_storage only works on HTTPS or localhost environments. [Please se
 A Flutter plugin to store data in secure storage:
 
 - [Keychain](https://developer.apple.com/library/content/documentation/Security/Conceptual/keychainServConcepts/01introduction/introduction.html#//apple_ref/doc/uid/TP30000897-CH203-TP1) is used for iOS
-- AES encryption is used for Android. AES secret key is encrypted with RSA and RSA key is stored in [KeyStore](https://developer.android.com/training/articles/keystore.html)
+- AES encryption is used for Android. AES secret key is encrypted with RSA and RSA key is stored in [KeyStore](https://developer.android.com/training/articles/keystore.html).   
+  By default following algorithms are used for AES and secret key encryption: AES/CBC/PKCS7Padding and RSA/ECB/PKCS1Padding  
+  From Android 6 you can use newer, recommended algoritms:  
+  AES/GCM/NoPadding and RSA/ECB/OAEPWithSHA-256AndMGF1Padding  
+  You can set them in Android options like so:
+```dart
+  AndroidOptions _getAndroidOptions() => const AndroidOptions(
+         keyCipherAlgorithm: KeyCipherAlgorithm.RSA_ECB_OAEPwithSHA_256andMGF1Padding,
+         storageCipherAlgorithm: StorageCipherAlgorithm.AES_GCM_NoPadding,
+      );
+```
+On devices running Android with version less than 6, plugin will fall back to default implementation. You can change the algorithm, even if you already have some encrypted preferences - they will be re-encrypted using selected algorithms.
+Choosing algorithm is irrelevant if you are using EncryptedSharedPreferences as described below.
 - With v5.0.0 we can use [EncryptedSharedPreferences](https://developer.android.com/topic/security/data) on Android by enabling it in the Android Options like so:
 ```dart
   AndroidOptions _getAndroidOptions() => const AndroidOptions(
-        encryptedSharedPreferences: true,
-      );
-```    
-  For more information see the example app.
+  encryptedSharedPreferences: true,
+);
+```
+For more information see the example app.
 - [`libsecret`](https://wiki.gnome.org/Projects/Libsecret) is used for Linux.
 
 _Note_ KeyStore was introduced in Android 4.3 (API level 18). The plugin wouldn't work for earlier versions.

--- a/flutter_secure_storage/android/gradle/wrapper/gradle-wrapper.properties
+++ b/flutter_secure_storage/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Sep 20 15:16:53 ICT 2018
+#Tue May 17 09:58:24 CEST 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -113,7 +113,6 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
 
     private void reEncryptPreferences(StorageCipherFactory storageCipherFactory, SharedPreferences source) throws Exception {
         try {
-            Log.i(TAG, "re-encrypting");
             storageCipher = storageCipherFactory.getSavedStorageCipher(applicationContext);
             final Map<String, String> cache = new HashMap<>();
             for (Map.Entry<String, ?> entry : source.getAll().entrySet()) {

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipher.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/KeyCipher.java
@@ -1,0 +1,8 @@
+package com.it_nomads.fluttersecurestorage.ciphers;
+
+import java.security.Key;
+
+public interface KeyCipher {
+    byte[] wrap(Key key) throws Exception;
+    Key unwrap(byte[] wrappedKey, String algorithm) throws Exception;
+}

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipher18Implementation.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipher18Implementation.java
@@ -7,6 +7,8 @@ import android.os.Build;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
 
+import androidx.annotation.RequiresApi;
+
 import java.math.BigInteger;
 import java.security.Key;
 import java.security.KeyPairGenerator;
@@ -21,18 +23,22 @@ import java.util.Locale;
 import javax.crypto.Cipher;
 import javax.security.auth.x500.X500Principal;
 
-class RSACipher18Implementation {
+class RSACipher18Implementation implements KeyCipher{
 
     private static final String KEYSTORE_PROVIDER_ANDROID = "AndroidKeyStore";
     private static final String TYPE_RSA = "RSA";
-    private final String KEY_ALIAS;
-    private final Context context;
+    protected final String keyAlias;
+    protected final Context context;
 
 
     public RSACipher18Implementation(Context context) throws Exception {
-        KEY_ALIAS = context.getPackageName() + ".FlutterSecureStoragePluginKey";
         this.context = context;
+        keyAlias = createKeyAlias();
         createRSAKeysIfNeeded(context);
+    }
+
+    protected String createKeyAlias() {
+        return context.getPackageName() + ".FlutterSecureStoragePluginKey";
     }
 
     public byte[] wrap(Key key) throws Exception {
@@ -51,29 +57,13 @@ class RSACipher18Implementation {
         return cipher.unwrap(wrappedKey, algorithm, Cipher.SECRET_KEY);
     }
 
-    public byte[] encrypt(byte[] input) throws Exception {
-        PublicKey publicKey = getPublicKey();
-        Cipher cipher = getRSACipher();
-        cipher.init(Cipher.ENCRYPT_MODE, publicKey);
-
-        return cipher.doFinal(input);
-    }
-
-    public byte[] decrypt(byte[] input) throws Exception {
-        PrivateKey privateKey = getPrivateKey();
-        Cipher cipher = getRSACipher();
-        cipher.init(Cipher.DECRYPT_MODE, privateKey);
-
-        return cipher.doFinal(input);
-    }
-
     private PrivateKey getPrivateKey() throws Exception {
         KeyStore ks = KeyStore.getInstance(KEYSTORE_PROVIDER_ANDROID);
         ks.load(null);
 
-        Key key = ks.getKey(KEY_ALIAS, null);
+        Key key = ks.getKey(keyAlias, null);
         if (key == null) {
-            throw new Exception("No key found under alias: " + KEY_ALIAS);
+            throw new Exception("No key found under alias: " + keyAlias);
         }
 
         if (!(key instanceof PrivateKey)) {
@@ -87,20 +77,20 @@ class RSACipher18Implementation {
         KeyStore ks = KeyStore.getInstance(KEYSTORE_PROVIDER_ANDROID);
         ks.load(null);
 
-        Certificate cert = ks.getCertificate(KEY_ALIAS);
+        Certificate cert = ks.getCertificate(keyAlias);
         if (cert == null) {
-            throw new Exception("No certificate found under alias: " + KEY_ALIAS);
+            throw new Exception("No certificate found under alias: " + keyAlias);
         }
 
         PublicKey key = cert.getPublicKey();
         if (key == null) {
-            throw new Exception("No key found under alias: " + KEY_ALIAS);
+            throw new Exception("No key found under alias: " + keyAlias);
         }
 
         return key;
     }
 
-    private Cipher getRSACipher() throws Exception {
+    protected Cipher getRSACipher() throws Exception {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             return Cipher.getInstance("RSA/ECB/PKCS1Padding", "AndroidOpenSSL"); // error in android 6: InvalidKeyException: Need RSA private or public key
         } else {
@@ -112,7 +102,7 @@ class RSACipher18Implementation {
         KeyStore ks = KeyStore.getInstance(KEYSTORE_PROVIDER_ANDROID);
         ks.load(null);
 
-        Key privateKey = ks.getKey(KEY_ALIAS, null);
+        Key privateKey = ks.getKey(keyAlias, null);
         if (privateKey == null) {
             createKeys(context);
         }
@@ -148,17 +138,6 @@ class RSACipher18Implementation {
         config.setLocale(locale);
     }
 
-    @SuppressWarnings("deprecation")
-    private AlgorithmParameterSpec makeAlgorithmParameterSpecLegacy(Context context, Calendar start, Calendar end) {
-        return new android.security.KeyPairGeneratorSpec.Builder(context)
-                .setAlias(KEY_ALIAS)
-                .setSubject(new X500Principal("CN=" + KEY_ALIAS))
-                .setSerialNumber(BigInteger.valueOf(1))
-                .setStartDate(start.getTime())
-                .setEndDate(end.getTime())
-                .build();
-    }
-
     private void createKeys(Context context) throws Exception {
         final Locale localeBeforeFakingEnglishLocale = Locale.getDefault();
         try {
@@ -174,16 +153,7 @@ class RSACipher18Implementation {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
                 spec = makeAlgorithmParameterSpecLegacy(context, start, end);
             } else {
-                KeyGenParameterSpec.Builder builder = new KeyGenParameterSpec.Builder(KEY_ALIAS, KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)
-                        .setCertificateSubject(new X500Principal("CN=" + KEY_ALIAS))
-                        .setDigests(KeyProperties.DIGEST_SHA256)
-                        .setBlockModes(KeyProperties.BLOCK_MODE_ECB)
-                        .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
-                        .setCertificateSerialNumber(BigInteger.valueOf(1))
-                        .setCertificateNotBefore(start.getTime())
-                        .setCertificateNotAfter(end.getTime());
-
-                spec = builder.build();
+                spec = makeAlgorithmParameterSpec(context, start, end);
             }
 
             kpGenerator.initialize(spec);
@@ -191,5 +161,29 @@ class RSACipher18Implementation {
         } finally {
             setLocale(localeBeforeFakingEnglishLocale);
         }
+    }
+
+    @SuppressWarnings("deprecation")
+    private AlgorithmParameterSpec makeAlgorithmParameterSpecLegacy(Context context, Calendar start, Calendar end) {
+        return new android.security.KeyPairGeneratorSpec.Builder(context)
+                .setAlias(keyAlias)
+                .setSubject(new X500Principal("CN=" + keyAlias))
+                .setSerialNumber(BigInteger.valueOf(1))
+                .setStartDate(start.getTime())
+                .setEndDate(end.getTime())
+                .build();
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    protected AlgorithmParameterSpec makeAlgorithmParameterSpec(Context context, Calendar start, Calendar end) {
+        final KeyGenParameterSpec.Builder builder = new KeyGenParameterSpec.Builder(keyAlias, KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)
+                .setCertificateSubject(new X500Principal("CN=" + keyAlias))
+                .setDigests(KeyProperties.DIGEST_SHA256)
+                .setBlockModes(KeyProperties.BLOCK_MODE_ECB)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
+                .setCertificateSerialNumber(BigInteger.valueOf(1))
+                .setCertificateNotBefore(start.getTime())
+                .setCertificateNotAfter(end.getTime());
+        return builder.build();
     }
 }

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipher18Implementation.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipher18Implementation.java
@@ -41,18 +41,20 @@ class RSACipher18Implementation implements KeyCipher{
         return context.getPackageName() + ".FlutterSecureStoragePluginKey";
     }
 
+    @Override
     public byte[] wrap(Key key) throws Exception {
         PublicKey publicKey = getPublicKey();
         Cipher cipher = getRSACipher();
-        cipher.init(Cipher.WRAP_MODE, publicKey);
+        cipher.init(Cipher.WRAP_MODE, publicKey, getAlgorithmParameterSpec());
 
         return cipher.wrap(key);
     }
 
+    @Override
     public Key unwrap(byte[] wrappedKey, String algorithm) throws Exception {
         PrivateKey privateKey = getPrivateKey();
         Cipher cipher = getRSACipher();
-        cipher.init(Cipher.UNWRAP_MODE, privateKey);
+        cipher.init(Cipher.UNWRAP_MODE, privateKey, getAlgorithmParameterSpec());
 
         return cipher.unwrap(wrappedKey, algorithm, Cipher.SECRET_KEY);
     }
@@ -96,6 +98,10 @@ class RSACipher18Implementation implements KeyCipher{
         } else {
             return Cipher.getInstance("RSA/ECB/PKCS1Padding", "AndroidKeyStoreBCWorkaround"); // error in android 5: NoSuchProviderException: Provider not available: AndroidKeyStoreBCWorkaround
         }
+    }
+
+    protected AlgorithmParameterSpec getAlgorithmParameterSpec() {
+        return null;
     }
 
     private void createRSAKeysIfNeeded(Context context) throws Exception {

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipherOAEPImplementation.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipherOAEPImplementation.java
@@ -1,0 +1,53 @@
+package com.it_nomads.fluttersecurestorage.ciphers;
+
+import android.content.Context;
+import android.os.Build;
+import android.security.keystore.KeyGenParameterSpec;
+import android.security.keystore.KeyProperties;
+
+import androidx.annotation.RequiresApi;
+
+import java.math.BigInteger;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.MGF1ParameterSpec;
+import java.util.Calendar;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.OAEPParameterSpec;
+import javax.crypto.spec.PSource;
+import javax.security.auth.x500.X500Principal;
+
+public class RSACipherOAEPImplementation extends RSACipher18Implementation {
+
+    public RSACipherOAEPImplementation(Context context) throws Exception {
+        super(context);
+    }
+
+    @Override
+    protected String createKeyAlias() {
+        return context.getPackageName() + ".FlutterSecureStoragePluginKeyOAEP";
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    @Override
+    protected AlgorithmParameterSpec makeAlgorithmParameterSpec(Context context, Calendar start, Calendar end) {
+        final KeyGenParameterSpec.Builder builder = new KeyGenParameterSpec.Builder(keyAlias, KeyProperties.PURPOSE_DECRYPT | KeyProperties.PURPOSE_ENCRYPT)
+                .setCertificateSubject(new X500Principal("CN=" + keyAlias))
+                .setDigests(KeyProperties.DIGEST_SHA256)
+                .setBlockModes(KeyProperties.BLOCK_MODE_ECB)
+                .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_OAEP)
+                .setCertificateSerialNumber(BigInteger.valueOf(1))
+                .setCertificateNotBefore(start.getTime())
+                .setCertificateNotAfter(end.getTime());
+        return builder.build();
+    }
+
+    @Override
+    protected Cipher getRSACipher() throws Exception {
+        return Cipher.getInstance("RSA/ECB/OAEPPadding", "AndroidKeyStoreBCWorkaround"); // error in android 5: NoSuchProviderException: Provider not available: AndroidKeyStoreBCWorkaround
+    }
+
+    protected AlgorithmParameterSpec getAlgorithmParameterSpec() {
+        return new OAEPParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA1, PSource.PSpecified.DEFAULT);
+    }
+}

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipherOAEPImplementation.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/RSACipherOAEPImplementation.java
@@ -44,7 +44,7 @@ public class RSACipherOAEPImplementation extends RSACipher18Implementation {
 
     @Override
     protected Cipher getRSACipher() throws Exception {
-        return Cipher.getInstance("RSA/ECB/OAEPPadding", "AndroidKeyStoreBCWorkaround"); // error in android 5: NoSuchProviderException: Provider not available: AndroidKeyStoreBCWorkaround
+        return Cipher.getInstance("RSA/ECB/OAEPPadding", "AndroidKeyStoreBCWorkaround");
     }
 
     protected AlgorithmParameterSpec getAlgorithmParameterSpec() {

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherFactory.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherFactory.java
@@ -1,0 +1,91 @@
+package com.it_nomads.fluttersecurestorage.ciphers;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Build;
+
+import java.util.Map;
+
+@FunctionalInterface
+interface StorageCipherFunction {
+    StorageCipher apply(Context context, KeyCipher keyCipher) throws Exception;
+}
+
+@FunctionalInterface
+interface KeyCipherFunction {
+    KeyCipher apply(Context context) throws Exception;
+}
+
+enum KeyCipherAlgorithm {
+    RSA_ECB_PKCS1Padding(RSACipher18Implementation::new, 1),
+    @SuppressWarnings({"UnusedDeclaration"})
+    RSA_ECB_OAEPwithSHA_256andMGF1Padding(RSACipherOAEPImplementation::new, Build.VERSION_CODES.M);
+    final KeyCipherFunction keyCipher;
+    final int minVersionCode;
+
+    KeyCipherAlgorithm(KeyCipherFunction keyCipher, int minVersionCode) {
+        this.keyCipher = keyCipher;
+        this.minVersionCode = minVersionCode;
+    }
+}
+
+enum StorageCipherAlgorithm {
+    AES_CBC_PKCS7Padding(StorageCipher18Implementation::new, 1),
+    @SuppressWarnings({"UnusedDeclaration"})
+    AES_GCM_NoPadding(StorageCipherGCMImplementation::new, Build.VERSION_CODES.M);
+    final StorageCipherFunction storageCipher;
+    final int minVersionCode;
+
+    StorageCipherAlgorithm(StorageCipherFunction storageCipher, int minVersionCode) {
+        this.storageCipher = storageCipher;
+        this.minVersionCode = minVersionCode;
+    }
+}
+
+public class StorageCipherFactory {
+    private static final String ELEMENT_PREFERENCES_ALGORITHM_PREFIX = "FlutterSecureSAlgorithm";
+    private static final String ELEMENT_PREFERENCES_ALGORITHM_KEY = ELEMENT_PREFERENCES_ALGORITHM_PREFIX + "Key";
+    private static final String ELEMENT_PREFERENCES_ALGORITHM_STORAGE = ELEMENT_PREFERENCES_ALGORITHM_PREFIX + "Storage";
+    private static final KeyCipherAlgorithm DEFAULT_KEY_ALGORITHM = KeyCipherAlgorithm.RSA_ECB_PKCS1Padding;
+    private static final StorageCipherAlgorithm DEFAULT_STORAGE_ALGORITHM = StorageCipherAlgorithm.AES_CBC_PKCS7Padding;
+
+    private final KeyCipherAlgorithm savedKeyAlgorithm;
+    private final StorageCipherAlgorithm savedStorageAlgorithm;
+    private final KeyCipherAlgorithm currentKeyAlgorithm;
+    private final StorageCipherAlgorithm currentStorageAlgorithm;
+
+    public StorageCipherFactory(SharedPreferences source, Map<String, Object> options) {
+        savedKeyAlgorithm = KeyCipherAlgorithm.valueOf(source.getString(ELEMENT_PREFERENCES_ALGORITHM_KEY, DEFAULT_KEY_ALGORITHM.name()));
+        savedStorageAlgorithm = StorageCipherAlgorithm.valueOf(source.getString(ELEMENT_PREFERENCES_ALGORITHM_STORAGE, DEFAULT_STORAGE_ALGORITHM.name()));
+
+        final KeyCipherAlgorithm currentKeyAlgorithmTmp = KeyCipherAlgorithm.valueOf(getFromOptionsWithDefault(options,"keyCipherAlgorithm", DEFAULT_KEY_ALGORITHM.name()));
+        currentKeyAlgorithm = (currentKeyAlgorithmTmp.minVersionCode <= Build.VERSION.SDK_INT) ? currentKeyAlgorithmTmp : DEFAULT_KEY_ALGORITHM;
+        final StorageCipherAlgorithm currentStorageAlgorithmTmp = StorageCipherAlgorithm.valueOf(getFromOptionsWithDefault(options,"storageCipherAlgorithm", DEFAULT_STORAGE_ALGORITHM.name()));
+        currentStorageAlgorithm = (currentStorageAlgorithmTmp.minVersionCode <= Build.VERSION.SDK_INT) ? currentStorageAlgorithmTmp : DEFAULT_STORAGE_ALGORITHM;
+    }
+
+
+    private String getFromOptionsWithDefault(Map<String, Object> options, String key, String defaultValue) {
+        final Object value = options.get(key);
+        return value != null ? value.toString() : defaultValue;
+    }
+
+    public boolean requiresReEncryption() {
+        return savedKeyAlgorithm != currentKeyAlgorithm || savedStorageAlgorithm != currentStorageAlgorithm;
+    }
+
+    public StorageCipher getSavedStorageCipher(Context context) throws Exception {
+        final KeyCipher keyCipher = savedKeyAlgorithm.keyCipher.apply(context);
+        return savedStorageAlgorithm.storageCipher.apply(context,keyCipher);
+    }
+
+    public StorageCipher getCurrentStorageCipher(Context context) throws Exception {
+        final KeyCipher keyCipher = currentKeyAlgorithm.keyCipher.apply(context);
+        return currentStorageAlgorithm.storageCipher.apply(context,keyCipher);
+    }
+
+    public void storeCurrentAlgorithms(SharedPreferences.Editor editor) {
+        editor.putString(ELEMENT_PREFERENCES_ALGORITHM_KEY, currentKeyAlgorithm.name());
+        editor.putString(ELEMENT_PREFERENCES_ALGORITHM_STORAGE, currentStorageAlgorithm.name());
+    }
+}

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherFactory.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherFactory.java
@@ -88,4 +88,9 @@ public class StorageCipherFactory {
         editor.putString(ELEMENT_PREFERENCES_ALGORITHM_KEY, currentKeyAlgorithm.name());
         editor.putString(ELEMENT_PREFERENCES_ALGORITHM_STORAGE, currentStorageAlgorithm.name());
     }
+
+    public void removeCurrentAlgorithms(SharedPreferences.Editor editor) {
+        editor.remove(ELEMENT_PREFERENCES_ALGORITHM_KEY);
+        editor.remove(ELEMENT_PREFERENCES_ALGORITHM_STORAGE);
+    }
 }

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherGCMImplementation.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipherGCMImplementation.java
@@ -1,0 +1,42 @@
+package com.it_nomads.fluttersecurestorage.ciphers;
+
+import android.content.Context;
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
+
+import java.security.spec.AlgorithmParameterSpec;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+
+public class StorageCipherGCMImplementation extends StorageCipher18Implementation {
+
+    private static final int AUTHENTICATION_TAG_SIZE = 128;
+
+    public StorageCipherGCMImplementation(Context context, KeyCipher keyCipher) throws Exception {
+        super(context, keyCipher);
+    }
+
+    @Override
+    protected String getAESPreferencesKey() {
+        return "VGhpcyBpcyB0aGUga2V5IGZvcihBIHNlY3XyZZBzdG9yYWdlIEFFUyBLZXkK";
+    }
+
+    @Override
+    protected Cipher getCipher() throws Exception {
+        return Cipher.getInstance("AES/GCM/NoPadding");
+    }
+
+    protected int getIvSize() {
+        return 12;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.KITKAT)
+    @Override
+    protected AlgorithmParameterSpec getParameterSpec(byte[] iv) {
+        return new GCMParameterSpec(AUTHENTICATION_TAG_SIZE, iv);
+    }
+
+}

--- a/flutter_secure_storage/lib/options/android_options.dart
+++ b/flutter_secure_storage/lib/options/android_options.dart
@@ -14,8 +14,10 @@ class AndroidOptions extends Options {
   const AndroidOptions({
     bool encryptedSharedPreferences = false,
     bool resetOnError = false,
-    KeyCipherAlgorithm keyCipherAlgorithm = KeyCipherAlgorithm.RSA_ECB_PKCS1Padding,
-    StorageCipherAlgorithm storageCipherAlgorithm = StorageCipherAlgorithm.AES_CBC_PKCS7Padding,
+    KeyCipherAlgorithm keyCipherAlgorithm =
+        KeyCipherAlgorithm.RSA_ECB_PKCS1Padding,
+    StorageCipherAlgorithm storageCipherAlgorithm =
+        StorageCipherAlgorithm.AES_CBC_PKCS7Padding,
   })  : _encryptedSharedPreferences = encryptedSharedPreferences,
         _resetOnError = resetOnError,
         _keyCipherAlgorithm = keyCipherAlgorithm,
@@ -62,9 +64,11 @@ class AndroidOptions extends Options {
     StorageCipherAlgorithm? storageCipherAlgorithm,
   }) =>
       AndroidOptions(
-        encryptedSharedPreferences: encryptedSharedPreferences ?? _encryptedSharedPreferences,
+        encryptedSharedPreferences:
+            encryptedSharedPreferences ?? _encryptedSharedPreferences,
         resetOnError: resetOnError ?? _resetOnError,
         keyCipherAlgorithm: keyCipherAlgorithm ?? _keyCipherAlgorithm,
-        storageCipherAlgorithm: storageCipherAlgorithm ?? _storageCipherAlgorithm,
+        storageCipherAlgorithm:
+            storageCipherAlgorithm ?? _storageCipherAlgorithm,
       );
 }

--- a/flutter_secure_storage/lib/options/android_options.dart
+++ b/flutter_secure_storage/lib/options/android_options.dart
@@ -1,10 +1,25 @@
 part of flutter_secure_storage;
 
+enum KeyCipherAlgorithm {
+  RSA_ECB_PKCS1Padding,
+  RSA_ECB_OAEPwithSHA_256andMGF1Padding,
+}
+
+enum StorageCipherAlgorithm {
+  AES_CBC_PKCS7Padding,
+  AES_GCM_NoPadding,
+}
+
 class AndroidOptions extends Options {
-  const AndroidOptions(
-      {bool encryptedSharedPreferences = false, bool resetOnError = false})
-      : _encryptedSharedPreferences = encryptedSharedPreferences,
-        _resetOnError = resetOnError;
+  const AndroidOptions({
+    bool encryptedSharedPreferences = false,
+    bool resetOnError = false,
+    KeyCipherAlgorithm keyCipherAlgorithm = KeyCipherAlgorithm.RSA_ECB_PKCS1Padding,
+    StorageCipherAlgorithm storageCipherAlgorithm = StorageCipherAlgorithm.AES_CBC_PKCS7Padding,
+  })  : _encryptedSharedPreferences = encryptedSharedPreferences,
+        _resetOnError = resetOnError,
+        _keyCipherAlgorithm = keyCipherAlgorithm,
+        _storageCipherAlgorithm = storageCipherAlgorithm;
 
   /// EncryptedSharedPrefences are only available on API 23 and greater
   final bool _encryptedSharedPreferences;
@@ -16,18 +31,40 @@ class AndroidOptions extends Options {
   /// Defaults to false.
   final bool _resetOnError;
 
+  /// If EncryptedSharedPrefences is set to false, you can select algorithm
+  /// that will be used to encrypt secret key.
+  /// By default RSA/ECB/PKCS1Padding if used.
+  /// Newer RSA/ECB/OAEPWithSHA-256AndMGF1Padding is available from Android 6.
+  /// Plugin will fall back to default algorithm in previous system versions.
+  final KeyCipherAlgorithm _keyCipherAlgorithm;
+
+  /// If EncryptedSharedPrefences is set to false, you can select algorithm
+  /// that will be used to encrypt properties.
+  /// By default AES/CBC/PKCS7Padding if used.
+  /// Newer AES/GCM/NoPadding is available from Android 6.
+  /// Plugin will fall back to default algorithm in previous system versions.
+  final StorageCipherAlgorithm _storageCipherAlgorithm;
+
   static const AndroidOptions defaultOptions = AndroidOptions();
 
   @override
   Map<String, String> toMap() => <String, String>{
         'encryptedSharedPreferences': '$_encryptedSharedPreferences',
-        'resetOnError': '$_resetOnError'
+        'resetOnError': '$_resetOnError',
+        'keyCipherAlgorithm': describeEnum(_keyCipherAlgorithm),
+        'storageCipherAlgorithm': describeEnum(_storageCipherAlgorithm),
       };
 
-  AndroidOptions copyWith(
-          {bool? encryptedSharedPreferences, bool? resetOnError}) =>
+  AndroidOptions copyWith({
+    bool? encryptedSharedPreferences,
+    bool? resetOnError,
+    KeyCipherAlgorithm? keyCipherAlgorithm,
+    StorageCipherAlgorithm? storageCipherAlgorithm,
+  }) =>
       AndroidOptions(
-          encryptedSharedPreferences:
-              encryptedSharedPreferences ?? _encryptedSharedPreferences,
-          resetOnError: resetOnError ?? _resetOnError);
+        encryptedSharedPreferences: encryptedSharedPreferences ?? _encryptedSharedPreferences,
+        resetOnError: resetOnError ?? _resetOnError,
+        keyCipherAlgorithm: keyCipherAlgorithm ?? _keyCipherAlgorithm,
+        storageCipherAlgorithm: storageCipherAlgorithm ?? _storageCipherAlgorithm,
+      );
 }


### PR DESCRIPTION
During penetration tests of our applications it was found that for Android, FlutterSecureStorage plugin uses following algorithms:
RSA/ECB/PKCS1Padding
AES/CBC/PKCS7Padding
These mechanisms are considered outdated and vulnerable to padding oracle attack.
The severity of this discovery was assessed as low. Also it wasn't shown if, in this specific context, the beforementioned vulnerability really exists. Still it is recommended to switch to more modern alternatives.
I have added alternative implementation using RSA_ECB_OAEPwithSHA_256andMGF1Padding and AES_GCM_NoPadding. Algorithms can now be selected using AndroidOptions. If user changes implementation, properties will be re-encrypted.
As these algorithms are not available on Android less than 6, plugin will fall back to default on older devices.
I've tested this solution on a selection of devices ranging from Android 6 to 12

I don't want to migrate to EncryptedSharedPreferences as current implementation works perfectly fine for our customers and I have found few threads, stating that there are random problems with EncryptedSharedPreferences on different devices - please see link below.
[https://issuetracker.google.com/issues/176215143](url)
