### PR TITLE
Expose macOS Keychain options

### DIFF
--- a/flutter_secure_storage/lib/flutter_secure_storage.dart
+++ b/flutter_secure_storage/lib/flutter_secure_storage.dart
@@ -6,12 +6,13 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
 
-part './options/web_options.dart';
-part './options/ios_options.dart';
 part './options/android_options.dart';
+part './options/apple_options.dart';
+part './options/ios_options.dart';
 part './options/linux_options.dart';
-part './options/windows_options.dart';
 part './options/macos_options.dart';
+part './options/web_options.dart';
+part './options/windows_options.dart';
 
 class FlutterSecureStorage {
   final IOSOptions iOptions;

--- a/flutter_secure_storage/lib/options/apple_options.dart
+++ b/flutter_secure_storage/lib/options/apple_options.dart
@@ -1,0 +1,52 @@
+part of flutter_secure_storage;
+
+// KeyChain accessibility attributes as defined here:
+// https://developer.apple.com/documentation/security/ksecattraccessible?language=objc
+
+enum KeychainAccessibility {
+  // The data in the keychain can only be accessed when the device is unlocked.
+  // Only available if a passcode is set on the device.
+  // Items with this attribute do not migrate to a new device.
+  passcode,
+
+  // The data in the keychain item can be accessed only while the device is unlocked by the user.
+  unlocked,
+
+  // The data in the keychain item can be accessed only while the device is unlocked by the user.
+  // Items with this attribute do not migrate to a new device.
+  unlocked_this_device,
+
+  // The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by the user.
+  first_unlock,
+
+  // The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by the user.
+  // Items with this attribute do not migrate to a new device.
+  first_unlock_this_device,
+}
+
+abstract class AppleOptions extends Options {
+  const AppleOptions({
+    String? groupId,
+    String? accountName = AppleOptions.defaultAccountName,
+    KeychainAccessibility accessibility = KeychainAccessibility.unlocked,
+    bool synchronizable = false,
+  })  : _groupId = groupId,
+        _accessibility = accessibility,
+        _accountName = accountName,
+        _synchronizable = synchronizable;
+
+  static const defaultAccountName = 'flutter_secure_storage_service';
+
+  final String? _groupId;
+  final String? _accountName;
+  final KeychainAccessibility _accessibility;
+  final bool _synchronizable;
+
+  @override
+  Map<String, String> toMap() => <String, String>{
+        'accessibility': describeEnum(_accessibility),
+        if (_accountName != null) 'accountName': _accountName!,
+        if (_groupId != null) 'groupId': _groupId!,
+        'synchronizable': '$_synchronizable',
+      };
+}

--- a/flutter_secure_storage/lib/options/ios_options.dart
+++ b/flutter_secure_storage/lib/options/ios_options.dart
@@ -1,60 +1,24 @@
 part of flutter_secure_storage;
 
-// KeyChain accessibility attributes as defined here:
-// https://developer.apple.com/documentation/security/ksecattraccessible?language=objc
-enum IOSAccessibility {
-  // The data in the keychain can only be accessed when the device is unlocked.
-  // Only available if a passcode is set on the device.
-  // Items with this attribute do not migrate to a new device.
-  passcode,
-
-  // The data in the keychain item can be accessed only while the device is unlocked by the user.
-  unlocked,
-
-  // The data in the keychain item can be accessed only while the device is unlocked by the user.
-  // Items with this attribute do not migrate to a new device.
-  unlocked_this_device,
-
-  // The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by the user.
-  first_unlock,
-
-  // The data in the keychain item cannot be accessed after a restart until the device has been unlocked once by the user.
-  // Items with this attribute do not migrate to a new device.
-  first_unlock_this_device,
-}
-
-class IOSOptions extends Options {
+class IOSOptions extends AppleOptions {
   const IOSOptions({
     String? groupId,
-    String? accountName = IOSOptions.defaultAccountName,
-    IOSAccessibility accessibility = IOSAccessibility.unlocked,
+    String? accountName = AppleOptions.defaultAccountName,
+    KeychainAccessibility accessibility = KeychainAccessibility.unlocked,
     bool synchronizable = false,
-  })  : _groupId = groupId,
-        _accessibility = accessibility,
-        _accountName = accountName,
-        _synchronizable = synchronizable;
-
-  static const defaultAccountName = 'flutter_secure_storage_service';
+  }) : super(
+          groupId: groupId,
+          accountName: accountName,
+          accessibility: accessibility,
+          synchronizable: synchronizable,
+        );
 
   static const IOSOptions defaultOptions = IOSOptions();
-
-  final String? _groupId;
-  final String? _accountName;
-  final IOSAccessibility _accessibility;
-  final bool _synchronizable;
-
-  @override
-  Map<String, String> toMap() => <String, String>{
-        'accessibility': describeEnum(_accessibility),
-        if (_accountName != null) 'accountName': _accountName!,
-        if (_groupId != null) 'groupId': _groupId!,
-        'synchronizable': '$_synchronizable',
-      };
 
   IOSOptions copyWith({
     String? groupId,
     String? accountName,
-    IOSAccessibility? accessibility,
+    KeychainAccessibility? accessibility,
     bool? synchronizable,
   }) =>
       IOSOptions(

--- a/flutter_secure_storage/lib/options/macos_options.dart
+++ b/flutter_secure_storage/lib/options/macos_options.dart
@@ -1,10 +1,30 @@
 part of flutter_secure_storage;
 
-class MacOsOptions extends Options {
-  const MacOsOptions();
+class MacOsOptions extends AppleOptions {
+  const MacOsOptions({
+    String? groupId,
+    String? accountName = AppleOptions.defaultAccountName,
+    KeychainAccessibility accessibility = KeychainAccessibility.unlocked,
+    bool synchronizable = false,
+  }) : super(
+          groupId: groupId,
+          accountName: accountName,
+          accessibility: accessibility,
+          synchronizable: synchronizable,
+        );
 
   static const MacOsOptions defaultOptions = MacOsOptions();
 
-  @override
-  Map<String, String> toMap() => <String, String>{};
+  MacOsOptions copyWith({
+    String? groupId,
+    String? accountName,
+    KeychainAccessibility? accessibility,
+    bool? synchronizable,
+  }) =>
+      MacOsOptions(
+        groupId: groupId ?? _groupId,
+        accountName: accountName ?? _accountName,
+        accessibility: accessibility ?? _accessibility,
+        synchronizable: synchronizable ?? _synchronizable,
+      );
 }


### PR DESCRIPTION
Currently, we're only passing the Apple `Keychain` options on the iOS platform. macOS has everything wired up in `FlutterSecureStorageMacosPlugin.m`, but it's not passing the params from Flutter to the objective-c code.

This patch addresses this by:
1. Renaming `IOSAccessiblity` to `AppleAccessiblity` since `Keychain` is cross-platform in Apple's ecosystem
2. Created a shared `AppleOptions` abstract class that both `IOSOptions` and `MacOSOptions` extend.