### PR TITLE
Fix Linux: error not thrown when using secret service

### DIFF
--- a/flutter_secure_storage_linux/linux/include/Secret.hpp
+++ b/flutter_secure_storage_linux/linux/include/Secret.hpp
@@ -61,8 +61,8 @@ public:
         &the_schema, m_attributes.getGHashTable(), nullptr, label.c_str(),
         output.c_str(), nullptr, &errPtr);
 
-    if (err) {
-      throw err->message;
+    if (errPtr) {
+      throw errPtr->message;
     }
 
     return result;
@@ -78,8 +78,8 @@ public:
     const gchar *result = secret_password_lookupv_sync(
         &the_schema, m_attributes.getGHashTable(), nullptr, &errPtr);
 
-    if (err) {
-      throw err->message;
+    if (errPtr) {
+      throw errPtr->message;
     }
 
     if (result != nullptr && strcmp(result, "") != 0 &&


### PR DESCRIPTION
The code used the wrong variable when checking for an error. As a result no error was thrown if there was something wrong when accessing the secret service (i.e. gnome-keyring). Probably also adresses #353 