### PR TITLE
Add `setMockInitialValues` to enable test 

### DIFF
--- a/flutter_secure_storage/lib/flutter_secure_storage.dart
+++ b/flutter_secure_storage/lib/flutter_secure_storage.dart
@@ -32,7 +32,8 @@ class FlutterSecureStorage {
   });
 
   static const UNSUPPORTED_PLATFORM = 'unsupported_platform';
-  static final _platform = FlutterSecureStoragePlatform.instance;
+  FlutterSecureStoragePlatform get _platform =>
+      FlutterSecureStoragePlatform.instance;
 
   /// Encrypts and saves the [key] with the given [value].
   ///

--- a/flutter_secure_storage/lib/flutter_secure_storage.dart
+++ b/flutter_secure_storage/lib/flutter_secure_storage.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_secure_storage/test/test_flutter_secure_storage_platform.dart';
 import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
 
 part './options/android_options.dart';
@@ -258,5 +259,12 @@ class FlutterSecureStorage {
     } else {
       throw UnsupportedError(UNSUPPORTED_PLATFORM);
     }
+  }
+
+  /// Initializes the shared preferences with mock values for testing.
+  @visibleForTesting
+  static void setMockInitialValues(Map<String, String> values) {
+    FlutterSecureStoragePlatform.instance =
+        TestFlutterSecureStoragePlatform(values);
   }
 }

--- a/flutter_secure_storage/lib/test/test_flutter_secure_storage_platform.dart
+++ b/flutter_secure_storage/lib/test/test_flutter_secure_storage_platform.dart
@@ -1,0 +1,46 @@
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart';
+
+class TestFlutterSecureStoragePlatform extends FlutterSecureStoragePlatform {
+  final Map<String, String> data;
+
+  TestFlutterSecureStoragePlatform(this.data);
+
+  @override
+  Future<bool> containsKey({
+    required String key,
+    required Map<String, String> options,
+  }) async =>
+      data.containsKey(key);
+
+  @override
+  Future<void> delete({
+    required String key,
+    required Map<String, String> options,
+  }) async =>
+      data.remove(key);
+
+  @override
+  Future<void> deleteAll({required Map<String, String> options}) async =>
+      data.clear();
+
+  @override
+  Future<String?> read({
+    required String key,
+    required Map<String, String> options,
+  }) async =>
+      data[key];
+
+  @override
+  Future<Map<String, String>> readAll({
+    required Map<String, String> options,
+  }) async =>
+      data;
+
+  @override
+  Future<void> write({
+    required String key,
+    required String value,
+    required Map<String, String> options,
+  }) async =>
+      data[key] = value;
+}


### PR DESCRIPTION
Changes
* Avoid making a copy of `FlutterSecureStoragePlatform.instance` into a static final field, as which kills the possibility to have multiple mocks.
* Add `TestFlutterSecureStoragePlatform` to simulate the plugin behaviour, but everything is done in memory.
* Provide `SharedPreferences` like API to configure the mock.
