### PR TITLE
Perform Keychain operations asynchronously on a non-main thread.

### DIFF
--- a/flutter_secure_storage/ios/Classes/SwiftFlutterSecureStoragePlugin.swift
+++ b/flutter_secure_storage/ios/Classes/SwiftFlutterSecureStoragePlugin.swift
@@ -18,21 +18,30 @@ public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin {
     }
     
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-        switch (call.method) {
-        case "read":
-            read(call, result)
-        case "write":
-            write(call, result)
-        case "delete":
-            delete(call, result)
-        case "deleteAll":
-            deleteAll(call, result)
-        case "readAll":
-            readAll(call, result)
-        case "containsKey":
-            containsKey(call, result)
-        default:
-            result(FlutterMethodNotImplemented)
+        
+        func handleResult(_ value: Any?) {
+            DispatchQueue.main.async {
+                result(value)
+            }
+        }
+        
+        DispatchQueue.global(qos: .userInitiated).async {
+            switch (call.method) {
+            case "read":
+                self.read(call, handleResult)
+            case "write":
+                self.write(call, handleResult)
+            case "delete":
+                self.delete(call, handleResult)
+            case "deleteAll":
+                self.deleteAll(call, handleResult)
+            case "readAll":
+                self.readAll(call, handleResult)
+            case "containsKey":
+                self.containsKey(call, handleResult)
+            default:
+                handleResult(FlutterMethodNotImplemented)
+            }
         }
     }
     


### PR DESCRIPTION
Change to perform Keychain operations asynchronously on a non-main thread.

Apple suggest in documentation, that Keychain operations should be called from non-main thread to avoid undesired/unpredictable behaviour on the UI side:

quote
**Performance considerations**
SecItemCopyMatching blocks the calling thread, so it can cause your app’s UI to hang if called from the main thread. Instead, call SecItemCopyMatching from a background dispatch queue or async function.
unquote
https://developer.apple.com/documentation/security/1398306-secitemcopymatching
