### PR TITLE
Enhance security from AES-128 to AES-256

### DIFF
--- a/flutter_secure_storage/README.md
+++ b/flutter_secure_storage/README.md
@@ -16,7 +16,7 @@ For more info, [see this issue](https://github.com/mogol/flutter_secure_storage/
 A Flutter plugin to store data in secure storage:
 
 - [Keychain](https://developer.apple.com/library/content/documentation/Security/Conceptual/keychainServConcepts/01introduction/introduction.html#//apple_ref/doc/uid/TP30000897-CH203-TP1) is used for iOS
-- AES encryption is used for Android. AES secret key is encrypted with RSA and RSA key is stored in [KeyStore](https://developer.android.com/training/articles/keystore.html)
+- AES-256 encryption is used for Android. AES secret key is encrypted with RSA and RSA key is stored in [KeyStore](https://developer.android.com/training/articles/keystore.html)
 - With V5.0.0 we can use [EncryptedSharedPreferences](https://developer.android.com/topic/security/data) on Android by enabling it in the Android Options like so:
 ```dart
   AndroidOptions _getAndroidOptions() => const AndroidOptions(

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipher18Implementation.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/ciphers/StorageCipher18Implementation.java
@@ -14,7 +14,7 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 public class StorageCipher18Implementation implements StorageCipher {
-    private static final int keySize = 16;
+    private static final int keySize = 32;
     private static final String KEY_ALGORITHM = "AES";
     private static final String SHARED_PREFERENCES_NAME = "FlutterSecureKeyStorage";
     private final Cipher cipher;

--- a/flutter_secure_storage_windows/windows/flutter_secure_storage_windows_plugin.cpp
+++ b/flutter_secure_storage_windows/windows/flutter_secure_storage_windows_plugin.cpp
@@ -297,7 +297,7 @@ namespace
 
   PBYTE FlutterSecureStorageWindowsPlugin::GetEncryptionKey()
   {
-      const size_t KEY_SIZE = 16;
+      const size_t KEY_SIZE = 32;
       DWORD credError = 0;
       PBYTE AesKey;
       PCREDENTIALW pcred;
@@ -440,7 +440,7 @@ namespace
   {
       //The recommended size for AES-GCM IV is 12 bytes
       const DWORD NONCE_SIZE = 12;
-      const DWORD KEY_SIZE = 16;
+      const DWORD KEY_SIZE = 32;
 
       NTSTATUS status;
       BCRYPT_ALG_HANDLE algo = NULL;


### PR DESCRIPTION
There are many security guidelines and standards that recommend or require the use of strong encryption algorithms such as AES-256. For example, the National Institute of Standards and Technology (NIST) recommends using AES with a key size of at least 128 bits for protecting sensitive information. Similarly, other organizations and standards such as PCI DSS (Payment Card Industry Data Security Standard) also require the use of strong encryption algorithms like AES-256 for protecting sensitive data.