### PR TITLE
[windows] Error when calling `delete()` before application support path exists

### DIFF
--- a/flutter_secure_storage_windows/windows/flutter_secure_storage_windows_plugin.cpp
+++ b/flutter_secure_storage_windows/windows/flutter_secure_storage_windows_plugin.cpp
@@ -782,7 +782,7 @@ namespace
       BOOL ok = DeleteFile((appSupportPath + L"\\" + wstr + L".secure").c_str());
       if (!ok) {
           DWORD error = GetLastError();
-          if (error != ERROR_FILE_NOT_FOUND) {
+          if (error != ERROR_FILE_NOT_FOUND && error != ERROR_PATH_NOT_FOUND) {
               throw error;
           }
       }


### PR DESCRIPTION
Calling `delete()` while the application support path does not exist will throw an exception:

`PlatformException(Exception encountered: UNKNOWN_ERROR, delete, null, null)`

When calling DeleteFile() either ERROR_FILE_NOT_FOUND (0x2) or ERROR_PATH_NOT_FOUND (0x3) can be returned. This PR adds a check for ERROR_PATH_NOT_FOUND, as nothing should happen if the key does not exist.