### PR TITLE
[Windows] Fix charset problem

### DIFF
--- a/flutter_secure_storage_windows/windows/flutter_secure_storage_windows_plugin.cpp
+++ b/flutter_secure_storage_windows/windows/flutter_secure_storage_windows_plugin.cpp
@@ -239,8 +239,20 @@ namespace
               if (VerQueryValue(infoBuffer, TEXT("\\StringFileInfo\\040904e4\\CompanyName"), &queryVal, &queryLen) != 0) {
                   companyName = SanitizeDirString(std::wstring((const TCHAR*)queryVal));
               }
+              else if (VerQueryValue(infoBuffer, TEXT("\\StringFileInfo\\040904b0\\CompanyName"), &queryVal, &queryLen) != 0) {
+                  companyName = SanitizeDirString(std::wstring((const TCHAR*)queryVal));
+              }
+              else {
+                  companyName = L"placeholder_company";
+              }
               if (VerQueryValue(infoBuffer, TEXT("\\StringFileInfo\\040904e4\\ProductName"), &queryVal, &queryLen) != 0) {
                   productName = SanitizeDirString(std::wstring((const TCHAR*)queryVal));
+              }
+              else if (VerQueryValue(infoBuffer, TEXT("\\StringFileInfo\\040904b0\\ProductName"), &queryVal, &queryLen) != 0) {
+                  productName = SanitizeDirString(std::wstring((const TCHAR*)queryVal));
+              }
+              else {
+                  productName = L"placeholder_product";
               }
           }
           stream << appdataPath << "\\" << companyName << "\\" << productName;
@@ -255,10 +267,14 @@ namespace
 
   std::wstring FlutterSecureStorageWindowsPlugin::SanitizeDirString(std::wstring string)
   {
-      std::wstring sanitizedString = std::regex_replace(string,std::wregex(L"[<>:\"/\\\\|?*]"),L"_");
-      rtrim(sanitizedString);
-      sanitizedString = std::regex_replace(sanitizedString, std::wregex(L"[.]+$"), L"");
-      return sanitizedString;
+      std::wstring illegalChars = L"\\/:?\"<>|";
+      for (auto it = string.begin(); it < string.end(); ++it) {
+          if (illegalChars.find(*it) != std::wstring::npos) {
+              *it = L'_';
+          }
+      }
+      rtrim(string);
+      return string;
   }
 
   bool FlutterSecureStorageWindowsPlugin::PathExists(const std::wstring& path)


### PR DESCRIPTION
This fixes #574 a problem on Windows regarding the chosen charset in the Runner.rc file. Originally, the application would try to read the 040904e4 block in the Runner.rc file and would leave the values for `company` and `product_name` empty if the read failed. After this fix the application will try to read the 040904e4 block and the 040904b0 block if the first read failed. Additionally, the values for `company` and `product_name` will be set to a default value if both read operations failed. This fix also addresses some problems regarding path sanitization. 