### PR TITLE
Enable `buildFeatures` to support AGP8

### DIFF
--- a/flutter_secure_storage/android/build.gradle
+++ b/flutter_secure_storage/android/build.gradle
@@ -26,6 +26,10 @@ android {
         namespace("com.it_nomads.fluttersecurestorage")
     }
 
+    buildFeatures {
+        buildConfig = true
+    }
+
     compileSdkVersion 33
 
     compileOptions {


### PR DESCRIPTION
This fixes the following build error:

```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':flutter_secure_storage'.
> defaultConfig contains custom BuildConfig fields, but the feature is disabled.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 914ms
```