### PR TITLE
[Android] Get resetOnError from the options

### DIFF
--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStorage.java
@@ -47,6 +47,11 @@ public class FlutterSecureStorage {
     }
 
     @SuppressWarnings({"ConstantConditions"})
+    boolean getResetOnError() {
+        return options.containsKey("resetOnError") && options.get("resetOnError").equals("true");
+    }
+
+    @SuppressWarnings({"ConstantConditions"})
     private boolean getUseEncryptedSharedPreferences() {
         if (failedToUseEncryptedSharedPreferences) {
             return false;

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -185,14 +185,22 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                 Log.i("Creating sharedPrefs", e.getLocalizedMessage());
             } catch (Exception e) {
                 if (resetOnError) {
-                    secureStorage.deleteAll();
-                    result.success("Data has been reset");
+                    try {
+                        secureStorage.deleteAll();
+                        result.success("Data has been reset");
+                    } catch (Exception ex) {
+                        handleException(ex);
+                    }
                 } else {
-                    StringWriter stringWriter = new StringWriter();
-                    e.printStackTrace(new PrintWriter(stringWriter));
-                    result.error("Exception encountered", call.method, stringWriter.toString());
+                    handleException(e);
                 }
             }
+        }
+
+        private void handleException(Exception e) {
+            StringWriter stringWriter = new StringWriter();
+            e.printStackTrace(new PrintWriter(stringWriter));
+            result.error("Exception encountered", call.method, stringWriter.toString());
         }
     }
 }

--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -67,12 +67,6 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
         workerThreadHandler.post(new MethodRunner(call, result));
     }
 
-    @SuppressWarnings({"unchecked", "ConstantConditions"})
-    private boolean getResetOnErrorFromCall(MethodCall call) {
-        Map<String, Object> arguments = (Map<String, Object>) call.arguments;
-        return arguments.containsKey("resetOnError") && arguments.get("resetOnError").equals("true");
-    }
-
     @SuppressWarnings("unchecked")
     private String getKeyFromCall(MethodCall call) {
         Map<String, Object> arguments = (Map<String, Object>) call.arguments;
@@ -135,7 +129,7 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
             boolean resetOnError = false;
             try {
                 secureStorage.options = (Map<String, Object>) ((Map<String, Object>) call.arguments).get("options");
-                resetOnError = getResetOnErrorFromCall(call);
+                resetOnError = secureStorage.getResetOnError();
                 switch (call.method) {
                     case "write": {
                         String key = getKeyFromCall(call);


### PR DESCRIPTION
`resetOnError` is obtained from the `call.arguments` but this is in the options, so now I guess `resetOnError` will always be false.

In this PR, I updated it to get `resetOnError` from the options and also catch `deleteAll` errors to avoid unexpected crashes. 