### PR TITLE
Fix native Android stacktraces in PlatformExceptions

### DIFF
--- a/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/flutter_secure_storage/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -189,18 +189,12 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                         secureStorage.deleteAll();
                         result.success("Data has been reset");
                     } catch (Exception ex) {
-                        handleException(ex);
+                        throw new RuntimeException(ex);
                     }
                 } else {
-                    handleException(e);
+                    throw new RuntimeException(e);
                 }
             }
-        }
-
-        private void handleException(Exception e) {
-            StringWriter stringWriter = new StringWriter();
-            e.printStackTrace(new PrintWriter(stringWriter));
-            result.error("Exception encountered", call.method, stringWriter.toString());
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/mogol/flutter_secure_storage/issues/460

As described on the [`PlatformException.stacktrace`](https://api.flutter.dev/flutter/services/PlatformException/stacktrace.html) docs, native exceptions on Android don't need to be set via `result`. Instead, it has to be done by throwing a RuntimeException.

If an exception isn't propagated to Flutter as described, the `PlatformException.stacktrace` property isn't populated. This negatively impacts tooling like Sentry, and other error monitoring tools.

Let me know if there are any follow-up changes are known.