### PR TITLE
Adressing MacOS build warnings

### DIFF
--- a/flutter_secure_storage_macos/macos/Classes/FlutterSecureStorage.swift
+++ b/flutter_secure_storage_macos/macos/Classes/FlutterSecureStorage.swift
@@ -145,13 +145,13 @@ class FlutterSecureStorage{
             return FlutterSecureStorageResponse(status: err.status, value: nil)
         }
 
-        var attrAccessible = parseAccessibleAttr(accessibility: accessibility);
+        let attrAccessible = parseAccessibleAttr(accessibility: accessibility);
         var keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: nil)
 
         if (keyExists) {
             
 
-            let update: [CFString: Any?] = [
+            var update: [CFString: Any?] = [
                 kSecValueData: value.data(using: String.Encoding.utf8),
                 kSecAttrAccessible: attrAccessible,
                 kSecAttrSynchronizable: synchronizable


### PR DESCRIPTION
Adressing two warnings:
```
flutter_secure_storage_macos/macos/Classes/FlutterSecureStorage.swift:160:23: error: cannot assign through subscript: 'update' is a 'let' constant
                update[kSecUseDataProtectionKeychain] = true
                ~~~~~~^
            let update: [CFString: Any?] = [
            ^~~
            var
** BUILD FAILED **
```

which causes the build to fail. And then:

```
flutter_secure_storage_macos/macos/Classes/FlutterSecureStorage.swift:148:13: warning: variable 'attrAccessible' was never mutated; consider changing to 'let' constant
        var attrAccessible = parseAccessibleAttr(accessibility: accessibility);
        ~~~ ^
        let
```

I suppose the first one will show up as a warning (of the second kind) for when `!#available(macOS 10.15, *)` as that causes the only write to it. If that is so, this might needs some slightly more code refactor to prevent either warning from showing up.