### PR TITLE
[windows] Fix compilation error for flutter_secure_storage_windows_ffi.dart

### DIFF
--- a/flutter_secure_storage_windows/CHANGELOG.md
+++ b/flutter_secure_storage_windows/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.0+1
+- Fix 'LocalFree' compilation error
+
 ## 3.0.0
 - Migrated to win32 package replacing C.
 - Changed PathNotFoundException to FileSystemException to be backwards compatible with Flutter SDK 2.12.0

--- a/flutter_secure_storage_windows/lib/src/flutter_secure_storage_windows_ffi.dart
+++ b/flutter_secure_storage_windows/lib/src/flutter_secure_storage_windows_ffi.dart
@@ -257,7 +257,7 @@ class DpapiJsonFileMapStorage extends MapStorage {
           );
         } finally {
           if (plainTextBlob.ref.pbData.address != NULL) {
-            if (LocalFree(plainTextBlob.ref.pbData).address != NULL) {
+            if (LocalFree(plainTextBlob.ref.pbData.address) != NULL) {
               debugPrint(
                 'load: Failed to LocalFree with: 0x${GetLastError().toHexString(32)}',
               );
@@ -375,7 +375,7 @@ class DpapiJsonFileMapStorage extends MapStorage {
         }
       } finally {
         if (encryptedTextBlob.ref.pbData.address != NULL) {
-          if (LocalFree(encryptedTextBlob.ref.pbData).address != NULL) {
+          if (LocalFree(encryptedTextBlob.ref.pbData.address) != NULL) {
             debugPrint(
               'save: Failed to LocalFree with: 0x${GetLastError().toHexString(32)}',
             );

--- a/flutter_secure_storage_windows/pubspec.yaml
+++ b/flutter_secure_storage_windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_secure_storage_windows
 description: Windows implementation of flutter_secure_storage. Please use flutter_secure_storage instead of this package.
 repository: https://github.com/mogol/flutter_secure_storage
-version: 3.0.0
+version: 3.0.0+1
 
 environment:
   sdk: '>=2.12.0 <4.0.0'


### PR DESCRIPTION
package:win32's `LocalFree` accepts `int` and return `int`.