### PR TITLE
Update js dependency and migrate to web

### DIFF
--- a/flutter_secure_storage_web/CHANGELOG.md
+++ b/flutter_secure_storage_web/CHANGELOG.md
@@ -1,4 +1,5 @@
-## 1.1.3
+## 1.2.0
+- Migrate away from `html` to `web`
 - Allow newer `js` versions to be used with this package
 
 ## 1.1.2

--- a/flutter_secure_storage_web/CHANGELOG.md
+++ b/flutter_secure_storage_web/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.3
+- Allow newer `js` versions to be used with this package
+
 ## 1.1.2
 - Update Dart SDK Constraint to support <4.0.0 instead of <3.0.0.
 

--- a/flutter_secure_storage_web/lib/flutter_secure_storage_web.dart
+++ b/flutter_secure_storage_web/lib/flutter_secure_storage_web.dart
@@ -187,12 +187,9 @@ class FlutterSecureStorageWeb extends FlutterSecureStoragePlatform {
   }
 
   @override
-  Future<bool> isCupertinoProtectedDataAvailable() async {
-    return false;
-  }
+  Future<bool> isCupertinoProtectedDataAvailable() => Future.value(true);
 
   @override
-  Stream<bool> get onCupertinoProtectedDataAvailabilityChanged async* {
-    yield false;
-  }
+  Stream<bool> get onCupertinoProtectedDataAvailabilityChanged =>
+      Stream.value(true);
 }

--- a/flutter_secure_storage_web/lib/flutter_secure_storage_web.dart
+++ b/flutter_secure_storage_web/lib/flutter_secure_storage_web.dart
@@ -183,9 +183,12 @@ class FlutterSecureStorageWeb extends FlutterSecureStoragePlatform {
   }
 
   @override
-  Future<bool> isCupertinoProtectedDataAvailable() => Future.value(false);
+  Future<bool> isCupertinoProtectedDataAvailable() async {
+    return false;
+  }
 
   @override
-  Stream<bool> get onCupertinoProtectedDataAvailabilityChanged =>
-      Stream.empty();
+  Stream<bool> get onCupertinoProtectedDataAvailabilityChanged async* {
+    yield false;
+  }
 }

--- a/flutter_secure_storage_web/lib/flutter_secure_storage_web.dart
+++ b/flutter_secure_storage_web/lib/flutter_secure_storage_web.dart
@@ -187,9 +187,9 @@ class FlutterSecureStorageWeb extends FlutterSecureStoragePlatform {
   }
 
   @override
-  Future<bool> isCupertinoProtectedDataAvailable() => Future.value(true);
+  Future<bool> isCupertinoProtectedDataAvailable() => Future.value(false);
 
   @override
   Stream<bool> get onCupertinoProtectedDataAvailabilityChanged =>
-      Stream.value(true);
+      const Stream.empty();
 }

--- a/flutter_secure_storage_web/lib/src/subtle.dart
+++ b/flutter_secure_storage_web/lib/src/subtle.dart
@@ -18,12 +18,12 @@
 library common;
 
 import 'dart:convert' show jsonDecode;
-import 'dart:html';
 import 'dart:js_util' as js_util;
 import 'dart:typed_data';
 
 import 'package:flutter_secure_storage_web/src/jsonwebkey.dart' show JsonWebKey;
 import 'package:js/js.dart';
+import 'package:web/web.dart' hide JsonWebKey;
 
 export 'jsonwebkey.dart' show JsonWebKey;
 

--- a/flutter_secure_storage_web/pubspec.yaml
+++ b/flutter_secure_storage_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_secure_storage_web
 description: Web implementation of flutter_secure_storage. Use flutter_secure_storage for the full flutter package.
 repository: https://github.com/mogol/flutter_secure_storage
-version: 1.1.2
+version: 1.1.3
 
 environment:
   sdk: ">=2.12.0 <4.0.0"
@@ -13,7 +13,7 @@ dependencies:
   flutter_secure_storage_platform_interface: ^1.0.1
   flutter_web_plugins:
     sdk: flutter
-  js: ^0.6.3
+  js: '>=0.6.3 <1.0.0'
 
 dev_dependencies:
   lint: ^2.0.0

--- a/flutter_secure_storage_web/pubspec.yaml
+++ b/flutter_secure_storage_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_secure_storage_web
 description: Web implementation of flutter_secure_storage. Use flutter_secure_storage for the full flutter package.
 repository: https://github.com/mogol/flutter_secure_storage
-version: 1.1.3
+version: 1.2.0
 
 environment:
   sdk: ">=2.12.0 <4.0.0"
@@ -14,6 +14,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   js: '>=0.6.3 <1.0.0'
+  web: '>=0.5.0 <1.0.0'
 
 dev_dependencies:
   lint: ^2.0.0


### PR DESCRIPTION
This allows newer versions of `js` being used in conjunction with `flutter_secure_storage`. Also, as `html` is about to get phased out, this PR already migrates to `web` as it is recommended practice to do so.

Fixes #670 
Fixes #679 
Fixes #683

If you want to use this **now**, you can do so via a `dependency_override`:
```yaml
dependency_overrides:
  flutter_secure_storage:
    git:
      url: https://github.com/ThexXTURBOXx/flutter_secure_storage.git
      ref: develop
      path: flutter_secure_storage
```
You probably need to also override the other subpackages similarly (I won't explain how to do that. Just do it as I have shown with the main package above).