### PR TITLE
iOS - Add Privacy Manifest

### DIFF
--- a/flutter_secure_storage/ios/Resources/PrivacyInfo.xcprivacy
+++ b/flutter_secure_storage/ios/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/flutter_secure_storage/ios/flutter_secure_storage.podspec
+++ b/flutter_secure_storage/ios/flutter_secure_storage.podspec
@@ -21,5 +21,6 @@ A Flutter plugin to store data in secure storage.
     # Flutter.framework does not contain a i386 slice.
     s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
     s.swift_version = '5.0'
+    s.resource_bundles = {'flutter_secure_storage' => ['Resources/PrivacyInfo.xcprivacy']}
 end
 

--- a/flutter_secure_storage_macos/macos/Resources/PrivacyInfo.xcprivacy
+++ b/flutter_secure_storage_macos/macos/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/flutter_secure_storage_macos/macos/flutter_secure_storage_macos.podspec
+++ b/flutter_secure_storage_macos/macos/flutter_secure_storage_macos.podspec
@@ -19,4 +19,5 @@ Flutter Secure Storage Plugin for MacOs
   s.platform = :osx, '10.14'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'
+  s.resource_bundles = {'flutter_secure_storage_macos' => ['Resources/PrivacyInfo.xcprivacy']}
 end


### PR DESCRIPTION
# Summary
Added an empty Privacy Manifest to the iOS project in preparation for the May 1st Deadline for 3rd Party SDKs that include native iOS code. 

# Description

> Starting May 1: You’ll need to include approved reasons for the listed APIs used by your app’s code to upload a new or updated app to App Store Connect.
> ...
> Make sure to use a version of the SDK that includes its privacy manifest and note that signatures are also required when the SDK is added as a binary dependency.

[Privacy updates for App Store submissions - Latest News - Apple Developer](https://developer.apple.com/news/?id=3d8a9yyh)
[Upcoming third-party SDK requirements - Support - Apple Developer](https://developer.apple.com/support/third-party-SDK-requirements/)

# Impact and Testing
Developers using an updated version of this library on their iOS projects shouldn't see any issues related to the Privacy Manifest

# Contributor Note
Based on the language on Apple's Website, this change seems to be mandatory for all 3rd Party Libraries. The impact of not adding it is unclear to me, but hopefully having it will be better than not.