### PR TITLE
Return nil on iOS read if key is not found

### DIFF
--- a/flutter_secure_storage/ios/Classes/FlutterSecureStorage.swift
+++ b/flutter_secure_storage/ios/Classes/FlutterSecureStorage.swift
@@ -139,6 +139,11 @@ class FlutterSecureStorage{
     internal func delete(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
         let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: true)
         let status = SecItemDelete(keychainQuery as CFDictionary)
+
+        // Return nil if the key is not found
+        if (status == errSecItemNotFound) {
+            return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
+        }
         
         return FlutterSecureStorageResponse(status: status, value: nil)
     }

--- a/flutter_secure_storage/ios/Classes/FlutterSecureStorage.swift
+++ b/flutter_secure_storage/ios/Classes/FlutterSecureStorage.swift
@@ -109,6 +109,11 @@ class FlutterSecureStorage{
             keychainQuery as CFDictionary,
             &ref
         )
+
+        // Return nil if the key is not found
+        if (status == errSecItemNotFound) {
+            return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
+        }
         
         var value: String? = nil
         


### PR DESCRIPTION
Fixes #709.

It looks like the `readAll` function was [updated in a recent commit](https://github.com/mogol/flutter_secure_storage/commit/a2ba4673842e5fe840f6928c8a4d9481060d0dbd#diff-a18a015af5fc9438706d6f278f142404f290313db58898aae4b3df63f9e8e598R86-R90) to explicitly return `nil` when a keychain key isn't found, but the `read` function was not updated to match the new error checking scheme.

I just added the same check for `errSecItemNotFound` and I am able to get my builds working on version 9.1.1.