### PR TITLE
Also set kSecUseDataProtectionKeychain on read for macos

### DIFF
--- a/flutter_secure_storage_macos/macos/Classes/FlutterSecureStorage.swift
+++ b/flutter_secure_storage_macos/macos/Classes/FlutterSecureStorage.swift
@@ -40,6 +40,9 @@ class FlutterSecureStorage{
             kSecClass : kSecClassGenericPassword,
             kSecAttrAccessible : parseAccessibleAttr(accessibility: accessibility),
         ]
+        if #available(macOS 10.15, *) {
+            keychainQuery[kSecUseDataProtectionKeychain] = true
+        }
         
         if (key != nil) {
             keychainQuery[kSecAttrAccount] = key


### PR DESCRIPTION
We were experiencing problems when using `synchronizable: false` on our Mac setup. After some investigation I found out that despite successfully able to write, even immediately after, the read would not return the updated value. Turns out that setting [`kSecUseDataProtectionKeychain`](https://developer.apple.com/documentation/security/ksecusedataprotectionkeychain) on write also means we need to set that on read or the value isn't properly found. The docs also recommend setting it to true always and we are doing that on write already, but weren't on the query.

This patch sets that key to true regardless of synchronizable being set fixing the issue for us.