### PR TITLE
Fix async race condition bug in storage operations

### DIFF
--- a/flutter_secure_storage/CHANGELOG.md
+++ b/flutter_secure_storage/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 9.2.1
+* Fix async race condition bug in storage operations.
+
 ## 9.2.0
 New Features:
 * [iOS, macOS] Reintroduced isProtectedDataAvailable.

--- a/flutter_secure_storage/lib/flutter_secure_storage.dart
+++ b/flutter_secure_storage/lib/flutter_secure_storage.dart
@@ -99,7 +99,7 @@ class FlutterSecureStorage {
     WindowsOptions? wOptions,
   }) async {
     if (value == null) {
-      _platform.delete(
+      await _platform.delete(
         key: key,
         options: _selectOptions(
           iOptions,
@@ -111,7 +111,7 @@ class FlutterSecureStorage {
         ),
       );
     } else {
-      _platform.write(
+      await _platform.write(
         key: key,
         value: value,
         options: _selectOptions(
@@ -211,7 +211,7 @@ class FlutterSecureStorage {
     MacOsOptions? mOptions,
     WindowsOptions? wOptions,
   }) async {
-    _platform.delete(
+    await _platform.delete(
       key: key,
       options: _selectOptions(
         iOptions,
@@ -282,7 +282,7 @@ class FlutterSecureStorage {
     MacOsOptions? mOptions,
     WindowsOptions? wOptions,
   }) async {
-    _platform.deleteAll(
+    await _platform.deleteAll(
       options: _selectOptions(
         iOptions,
         aOptions,
@@ -344,7 +344,7 @@ class FlutterSecureStorage {
   /// macOS: https://developer.apple.com/documentation/appkit/nsapplication/3752992-isprotecteddataavailable
   Future<bool?> isCupertinoProtectedDataAvailable() async =>
       _platform is MethodChannelFlutterSecureStorage
-          ? (_platform as MethodChannelFlutterSecureStorage)
+          ? await (_platform as MethodChannelFlutterSecureStorage)
               .isCupertinoProtectedDataAvailable()
           : null;
 

--- a/flutter_secure_storage/pubspec.yaml
+++ b/flutter_secure_storage/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_secure_storage
 description: Flutter Secure Storage provides API to store data in secure storage. Keychain is used in iOS, KeyStore based solution is used in Android.
-version: 9.2.0
+version: 9.2.0+1
 repository: https://github.com/mogol/flutter_secure_storage/tree/develop/flutter_secure_storage
 
 environment:

--- a/flutter_secure_storage/pubspec.yaml
+++ b/flutter_secure_storage/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_secure_storage
 description: Flutter Secure Storage provides API to store data in secure storage. Keychain is used in iOS, KeyStore based solution is used in Android.
-version: 9.2.0+1
+version: 9.2.1
 repository: https://github.com/mogol/flutter_secure_storage/tree/develop/flutter_secure_storage
 
 environment:


### PR DESCRIPTION
## Description
Race condition on `write` and `read`.

- [ ] Closes #716

## Solution
Using of `await` is necessary when switching from expression body returning feature (`=>`) to async block body (`{}`).