### PR TITLE
fix: [iOS / macOS] pass accessibility to `readAll` and `deleteAll`

### DIFF
--- a/flutter_secure_storage/ios/Classes/FlutterSecureStorage.swift
+++ b/flutter_secure_storage/ios/Classes/FlutterSecureStorage.swift
@@ -12,7 +12,7 @@ class FlutterSecureStorage{
         guard let accessibility = accessibility else {
             return kSecAttrAccessibleWhenUnlocked
         }
-        
+
         switch accessibility {
         case "passcode":
             return kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly
@@ -34,32 +34,32 @@ class FlutterSecureStorage{
             kSecClass : kSecClassGenericPassword,
             kSecAttrAccessible : parseAccessibleAttr(accessibility: accessibility),
         ]
-        
+
         if (key != nil) {
             keychainQuery[kSecAttrAccount] = key
         }
-        
+
         if (groupId != nil) {
             keychainQuery[kSecAttrAccessGroup] = groupId
         }
-        
+
         if (accountName != nil) {
             keychainQuery[kSecAttrService] = accountName
         }
-        
+
         if (synchronizable != nil) {
             keychainQuery[kSecAttrSynchronizable] = synchronizable
         }
-        
+
         if (returnData != nil) {
             keychainQuery[kSecReturnData] = returnData
         }
         return keychainQuery
     }
-    
-    internal func containsKey(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> Result<Bool, OSSecError> {  
+
+    internal func containsKey(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> Result<Bool, OSSecError> {
         let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: false)
-        
+
         let status = SecItemCopyMatching(keychainQuery as CFDictionary, nil)
         switch status {
         case errSecSuccess:
@@ -70,26 +70,26 @@ class FlutterSecureStorage{
             return .failure(OSSecError(status: status))
         }
     }
-    
-    internal func readAll(groupId: String?, accountName: String?, synchronizable: Bool?) -> FlutterSecureStorageResponse {
-        var keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: nil, returnData: true)
-        
+
+    internal func readAll(groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
+        var keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: true)
+
         keychainQuery[kSecMatchLimit] = kSecMatchLimitAll
         keychainQuery[kSecReturnAttributes] = true
-        
+
         var ref: AnyObject?
         let status = SecItemCopyMatching(
             keychainQuery as CFDictionary,
             &ref
         )
-        
+
         if (status == errSecItemNotFound) {
             // readAll() returns all elements, so return nil if the items does not exist
             return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
         }
 
         var results: [String: String] = [:]
-        
+
         if (status == noErr) {
             (ref as! NSArray).forEach { item in
                 let key: String = (item as! NSDictionary)[kSecAttrAccount] as! String
@@ -97,13 +97,13 @@ class FlutterSecureStorage{
                 results[key] = value
             }
         }
-        
+
         return FlutterSecureStorageResponse(status: status, value: results)
     }
-    
+
     internal func read(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
         let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: true)
-        
+
         var ref: AnyObject?
         let status = SecItemCopyMatching(
             keychainQuery as CFDictionary,
@@ -114,28 +114,28 @@ class FlutterSecureStorage{
         if (status == errSecItemNotFound) {
             return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
         }
-        
+
         var value: String? = nil
-        
+
         if (status == noErr) {
             value = String(data: ref as! Data, encoding: .utf8)
         }
 
         return FlutterSecureStorageResponse(status: status, value: value)
     }
-    
+
     internal func deleteAll(groupId: String?, accountName: String?, synchronizable: Bool?) -> FlutterSecureStorageResponse {
         let keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: nil, returnData: nil)
         let status = SecItemDelete(keychainQuery as CFDictionary)
-        
+
         if (status == errSecItemNotFound) {
             // deleteAll() deletes all items, so return nil if the items does not exist
             return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
         }
-        
+
         return FlutterSecureStorageResponse(status: status, value: nil)
     }
-    
+
     internal func delete(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
         let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: true)
         let status = SecItemDelete(keychainQuery as CFDictionary)
@@ -144,11 +144,11 @@ class FlutterSecureStorage{
         if (status == errSecItemNotFound) {
             return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
         }
-        
+
         return FlutterSecureStorageResponse(status: status, value: nil)
     }
-    
-    internal func write(key: String, value: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {        
+
+    internal func write(key: String, value: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
         var keyExists: Bool = false
 
     	switch containsKey(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility) {
@@ -163,24 +163,24 @@ class FlutterSecureStorage{
 
         if (keyExists) {
             let attrAccessible = parseAccessibleAttr(accessibility: accessibility)
-            
+
             let update: [CFString: Any?] = [
                 kSecValueData: value.data(using: String.Encoding.utf8),
                 kSecAttrAccessible: attrAccessible,
                 kSecAttrSynchronizable: synchronizable
             ]
-            
+
             let status = SecItemUpdate(keychainQuery as CFDictionary, update as CFDictionary)
-            
+
             return FlutterSecureStorageResponse(status: status, value: nil)
         } else {
             keychainQuery[kSecValueData] = value.data(using: String.Encoding.utf8)
-            
+
             let status = SecItemAdd(keychainQuery as CFDictionary, nil)
 
             return FlutterSecureStorageResponse(status: status, value: nil)
         }
-    }    
+    }
 }
 
 struct FlutterSecureStorageResponse {

--- a/flutter_secure_storage/ios/Classes/FlutterSecureStorage.swift
+++ b/flutter_secure_storage/ios/Classes/FlutterSecureStorage.swift
@@ -12,7 +12,7 @@ class FlutterSecureStorage{
         guard let accessibility = accessibility else {
             return kSecAttrAccessibleWhenUnlocked
         }
-
+        
         switch accessibility {
         case "passcode":
             return kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly
@@ -34,32 +34,32 @@ class FlutterSecureStorage{
             kSecClass : kSecClassGenericPassword,
             kSecAttrAccessible : parseAccessibleAttr(accessibility: accessibility),
         ]
-
+        
         if (key != nil) {
             keychainQuery[kSecAttrAccount] = key
         }
-
+        
         if (groupId != nil) {
             keychainQuery[kSecAttrAccessGroup] = groupId
         }
-
+        
         if (accountName != nil) {
             keychainQuery[kSecAttrService] = accountName
         }
-
+        
         if (synchronizable != nil) {
             keychainQuery[kSecAttrSynchronizable] = synchronizable
         }
-
+        
         if (returnData != nil) {
             keychainQuery[kSecReturnData] = returnData
         }
         return keychainQuery
     }
-
-    internal func containsKey(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> Result<Bool, OSSecError> {
+    
+    internal func containsKey(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> Result<Bool, OSSecError> {  
         let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: false)
-
+        
         let status = SecItemCopyMatching(keychainQuery as CFDictionary, nil)
         switch status {
         case errSecSuccess:
@@ -70,26 +70,26 @@ class FlutterSecureStorage{
             return .failure(OSSecError(status: status))
         }
     }
-
-    internal func readAll(groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
-        var keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: true)
-
+    
+    internal func readAll(groupId: String?, accountName: String?, synchronizable: Bool?) -> FlutterSecureStorageResponse {
+        var keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: nil, returnData: true)
+        
         keychainQuery[kSecMatchLimit] = kSecMatchLimitAll
         keychainQuery[kSecReturnAttributes] = true
-
+        
         var ref: AnyObject?
         let status = SecItemCopyMatching(
             keychainQuery as CFDictionary,
             &ref
         )
-
+        
         if (status == errSecItemNotFound) {
             // readAll() returns all elements, so return nil if the items does not exist
             return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
         }
 
         var results: [String: String] = [:]
-
+        
         if (status == noErr) {
             (ref as! NSArray).forEach { item in
                 let key: String = (item as! NSDictionary)[kSecAttrAccount] as! String
@@ -97,13 +97,13 @@ class FlutterSecureStorage{
                 results[key] = value
             }
         }
-
+        
         return FlutterSecureStorageResponse(status: status, value: results)
     }
-
+    
     internal func read(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
         let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: true)
-
+        
         var ref: AnyObject?
         let status = SecItemCopyMatching(
             keychainQuery as CFDictionary,
@@ -114,28 +114,28 @@ class FlutterSecureStorage{
         if (status == errSecItemNotFound) {
             return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
         }
-
+        
         var value: String? = nil
-
+        
         if (status == noErr) {
             value = String(data: ref as! Data, encoding: .utf8)
         }
 
         return FlutterSecureStorageResponse(status: status, value: value)
     }
-
+    
     internal func deleteAll(groupId: String?, accountName: String?, synchronizable: Bool?) -> FlutterSecureStorageResponse {
         let keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: nil, returnData: nil)
         let status = SecItemDelete(keychainQuery as CFDictionary)
-
+        
         if (status == errSecItemNotFound) {
             // deleteAll() deletes all items, so return nil if the items does not exist
             return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
         }
-
+        
         return FlutterSecureStorageResponse(status: status, value: nil)
     }
-
+    
     internal func delete(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
         let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: true)
         let status = SecItemDelete(keychainQuery as CFDictionary)
@@ -144,11 +144,11 @@ class FlutterSecureStorage{
         if (status == errSecItemNotFound) {
             return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
         }
-
+        
         return FlutterSecureStorageResponse(status: status, value: nil)
     }
-
-    internal func write(key: String, value: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
+    
+    internal func write(key: String, value: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {        
         var keyExists: Bool = false
 
     	switch containsKey(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility) {
@@ -163,24 +163,24 @@ class FlutterSecureStorage{
 
         if (keyExists) {
             let attrAccessible = parseAccessibleAttr(accessibility: accessibility)
-
+            
             let update: [CFString: Any?] = [
                 kSecValueData: value.data(using: String.Encoding.utf8),
                 kSecAttrAccessible: attrAccessible,
                 kSecAttrSynchronizable: synchronizable
             ]
-
+            
             let status = SecItemUpdate(keychainQuery as CFDictionary, update as CFDictionary)
-
+            
             return FlutterSecureStorageResponse(status: status, value: nil)
         } else {
             keychainQuery[kSecValueData] = value.data(using: String.Encoding.utf8)
-
+            
             let status = SecItemAdd(keychainQuery as CFDictionary, nil)
 
             return FlutterSecureStorageResponse(status: status, value: nil)
         }
-    }
+    }    
 }
 
 struct FlutterSecureStorageResponse {

--- a/flutter_secure_storage/ios/Classes/FlutterSecureStorage.swift
+++ b/flutter_secure_storage/ios/Classes/FlutterSecureStorage.swift
@@ -124,8 +124,8 @@ class FlutterSecureStorage{
         return FlutterSecureStorageResponse(status: status, value: value)
     }
     
-    internal func deleteAll(groupId: String?, accountName: String?, synchronizable: Bool?) -> FlutterSecureStorageResponse {
-        let keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: nil, returnData: nil)
+    internal func deleteAll(groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
+        let keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: nil)
         let status = SecItemDelete(keychainQuery as CFDictionary)
         
         if (status == errSecItemNotFound) {

--- a/flutter_secure_storage/ios/Classes/FlutterSecureStorage.swift
+++ b/flutter_secure_storage/ios/Classes/FlutterSecureStorage.swift
@@ -71,8 +71,8 @@ class FlutterSecureStorage{
         }
     }
     
-    internal func readAll(groupId: String?, accountName: String?, synchronizable: Bool?) -> FlutterSecureStorageResponse {
-        var keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: nil, returnData: true)
+    internal func readAll(groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
+        var keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: true)
         
         keychainQuery[kSecMatchLimit] = kSecMatchLimitAll
         keychainQuery[kSecReturnAttributes] = true

--- a/flutter_secure_storage/ios/Classes/SwiftFlutterSecureStoragePlugin.swift
+++ b/flutter_secure_storage/ios/Classes/SwiftFlutterSecureStoragePlugin.swift
@@ -135,7 +135,7 @@ public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterSt
     
     private func readAll(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
-        let response = flutterSecureStorageManager.readAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable)
+        let response = flutterSecureStorageManager.readAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
         
         handleResponse(response, result)
     }

--- a/flutter_secure_storage/ios/Classes/SwiftFlutterSecureStoragePlugin.swift
+++ b/flutter_secure_storage/ios/Classes/SwiftFlutterSecureStoragePlugin.swift
@@ -9,7 +9,7 @@ import Flutter
 import UIKit
 
 public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
-
+    
     private let flutterSecureStorageManager: FlutterSecureStorage = FlutterSecureStorage()
     private var secStoreAvailabilitySink: FlutterEventSink?
 
@@ -21,7 +21,7 @@ public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterSt
         registrar.addApplicationDelegate(instance)
         eventChannel.setStreamHandler(instance)
     }
-
+    
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         func handleResult(_ value: Any?) {
             DispatchQueue.main.async {
@@ -75,79 +75,79 @@ public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterSt
         self.secStoreAvailabilitySink = eventSink
         return nil
     }
-
+    
     public func onCancel(withArguments arguments: Any?) -> FlutterError? {
         self.secStoreAvailabilitySink = nil
         return nil
     }
-
+    
     private func read(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
         if (values.key == nil) {
             result(FlutterError.init(code: "Missing Parameter", message: "write requires key parameter", details: nil))
             return
         }
-
+        
         let response = flutterSecureStorageManager.read(key: values.key!, groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
         handleResponse(response, result)
     }
-
+    
     private func write(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         if (!((call.arguments as! [String : Any?])["value"] is String)){
             result(FlutterError.init(code: "Invalid Parameter", message: "key parameter must be String", details: nil))
             return;
         }
-
+        
         let values = parseCall(call)
         if (values.key == nil) {
             result(FlutterError.init(code: "Missing Parameter", message: "write requires key parameter", details: nil))
             return
         }
-
+        
         if (values.value == nil) {
             result(FlutterError.init(code: "Missing Parameter", message: "write requires value parameter", details: nil))
             return
         }
-
+        
         let response = flutterSecureStorageManager.write(key: values.key!, value: values.value!, groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
-
+        
         handleResponse(response, result)
     }
-
+    
     private func delete(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
         if (values.key == nil) {
             result(FlutterError.init(code: "Missing Parameter", message: "delete requires key parameter", details: nil))
             return
         }
-
+        
         let response = flutterSecureStorageManager.delete(key: values.key!, groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
-
+        
         handleResponse(response, result)
     }
-
+    
     private func deleteAll(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
         let response = flutterSecureStorageManager.deleteAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable)
-
+        
         handleResponse(response, result)
     }
-
+    
     private func readAll(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
-        let response = flutterSecureStorageManager.readAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
-
+        let response = flutterSecureStorageManager.readAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable)
+        
         handleResponse(response, result)
     }
-
+    
     private func containsKey(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
         if (values.key == nil) {
             result(FlutterError.init(code: "Missing Parameter", message: "containsKey requires key parameter", details: nil))
         }
-
+        
         let response = flutterSecureStorageManager.containsKey(key: values.key!, groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
-
+        
         switch response {
         case .success(let exists):
             result(exists)
@@ -168,27 +168,27 @@ public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterSt
             break;
         }
     }
-
+    
     private func parseCall(_ call: FlutterMethodCall) -> FlutterSecureStorageRequest {
         let arguments = call.arguments as! [String : Any?]
         let options = arguments["options"] as! [String : Any?]
-
+        
         let accountName = options["accountName"] as? String
         let groupId = options["groupId"] as? String
         let synchronizableString = options["synchronizable"] as? String
-
+        
         let synchronizable: Bool = synchronizableString != nil ? Bool(synchronizableString!)! : false
-
+        
         let key = arguments["key"] as? String
         let accessibility = options["accessibility"] as? String
         let value = arguments["value"] as? String
-
+        
         return FlutterSecureStorageRequest(
             accountName: accountName,
             groupId: groupId,
             synchronizable: synchronizable,
-            accessibility: accessibility,
-            key: key,
+            accessibility: accessibility, 
+            key: key, 
             value: value
         )
     }
@@ -215,7 +215,7 @@ public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterSt
             result(response.value)
         }
     }
-
+    
     struct FlutterSecureStorageRequest {
         var accountName: String?
         var groupId: String?
@@ -224,5 +224,5 @@ public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterSt
         var key: String?
         var value: String?
     }
-
+    
 }

--- a/flutter_secure_storage/ios/Classes/SwiftFlutterSecureStoragePlugin.swift
+++ b/flutter_secure_storage/ios/Classes/SwiftFlutterSecureStoragePlugin.swift
@@ -9,7 +9,7 @@ import Flutter
 import UIKit
 
 public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
-    
+
     private let flutterSecureStorageManager: FlutterSecureStorage = FlutterSecureStorage()
     private var secStoreAvailabilitySink: FlutterEventSink?
 
@@ -21,7 +21,7 @@ public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterSt
         registrar.addApplicationDelegate(instance)
         eventChannel.setStreamHandler(instance)
     }
-    
+
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         func handleResult(_ value: Any?) {
             DispatchQueue.main.async {
@@ -75,79 +75,79 @@ public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterSt
         self.secStoreAvailabilitySink = eventSink
         return nil
     }
-    
+
     public func onCancel(withArguments arguments: Any?) -> FlutterError? {
         self.secStoreAvailabilitySink = nil
         return nil
     }
-    
+
     private func read(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
         if (values.key == nil) {
             result(FlutterError.init(code: "Missing Parameter", message: "write requires key parameter", details: nil))
             return
         }
-        
+
         let response = flutterSecureStorageManager.read(key: values.key!, groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
         handleResponse(response, result)
     }
-    
+
     private func write(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         if (!((call.arguments as! [String : Any?])["value"] is String)){
             result(FlutterError.init(code: "Invalid Parameter", message: "key parameter must be String", details: nil))
             return;
         }
-        
+
         let values = parseCall(call)
         if (values.key == nil) {
             result(FlutterError.init(code: "Missing Parameter", message: "write requires key parameter", details: nil))
             return
         }
-        
+
         if (values.value == nil) {
             result(FlutterError.init(code: "Missing Parameter", message: "write requires value parameter", details: nil))
             return
         }
-        
+
         let response = flutterSecureStorageManager.write(key: values.key!, value: values.value!, groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
-        
+
         handleResponse(response, result)
     }
-    
+
     private func delete(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
         if (values.key == nil) {
             result(FlutterError.init(code: "Missing Parameter", message: "delete requires key parameter", details: nil))
             return
         }
-        
+
         let response = flutterSecureStorageManager.delete(key: values.key!, groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
-        
+
         handleResponse(response, result)
     }
-    
+
     private func deleteAll(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
         let response = flutterSecureStorageManager.deleteAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable)
-        
+
         handleResponse(response, result)
     }
-    
+
     private func readAll(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
-        let response = flutterSecureStorageManager.readAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable)
-        
+        let response = flutterSecureStorageManager.readAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
+
         handleResponse(response, result)
     }
-    
+
     private func containsKey(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
         if (values.key == nil) {
             result(FlutterError.init(code: "Missing Parameter", message: "containsKey requires key parameter", details: nil))
         }
-        
+
         let response = flutterSecureStorageManager.containsKey(key: values.key!, groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
-        
+
         switch response {
         case .success(let exists):
             result(exists)
@@ -168,27 +168,27 @@ public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterSt
             break;
         }
     }
-    
+
     private func parseCall(_ call: FlutterMethodCall) -> FlutterSecureStorageRequest {
         let arguments = call.arguments as! [String : Any?]
         let options = arguments["options"] as! [String : Any?]
-        
+
         let accountName = options["accountName"] as? String
         let groupId = options["groupId"] as? String
         let synchronizableString = options["synchronizable"] as? String
-        
+
         let synchronizable: Bool = synchronizableString != nil ? Bool(synchronizableString!)! : false
-        
+
         let key = arguments["key"] as? String
         let accessibility = options["accessibility"] as? String
         let value = arguments["value"] as? String
-        
+
         return FlutterSecureStorageRequest(
             accountName: accountName,
             groupId: groupId,
             synchronizable: synchronizable,
-            accessibility: accessibility, 
-            key: key, 
+            accessibility: accessibility,
+            key: key,
             value: value
         )
     }
@@ -215,7 +215,7 @@ public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterSt
             result(response.value)
         }
     }
-    
+
     struct FlutterSecureStorageRequest {
         var accountName: String?
         var groupId: String?
@@ -224,5 +224,5 @@ public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterSt
         var key: String?
         var value: String?
     }
-    
+
 }

--- a/flutter_secure_storage/ios/Classes/SwiftFlutterSecureStoragePlugin.swift
+++ b/flutter_secure_storage/ios/Classes/SwiftFlutterSecureStoragePlugin.swift
@@ -128,7 +128,7 @@ public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterSt
     
     private func deleteAll(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
-        let response = flutterSecureStorageManager.deleteAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable)
+        let response = flutterSecureStorageManager.deleteAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
         
         handleResponse(response, result)
     }

--- a/flutter_secure_storage_macos/macos/Classes/FlutterSecureStorage.swift
+++ b/flutter_secure_storage_macos/macos/Classes/FlutterSecureStorage.swift
@@ -127,8 +127,8 @@ class FlutterSecureStorage{
         return FlutterSecureStorageResponse(status: status, value: value)
     }
     
-    internal func deleteAll(groupId: String?, accountName: String?, synchronizable: Bool?) -> FlutterSecureStorageResponse {
-        let keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: nil, returnData: nil)
+    internal func deleteAll(groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
+        let keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: nil)
         let status = SecItemDelete(keychainQuery as CFDictionary)
         
         if (status == errSecItemNotFound) {

--- a/flutter_secure_storage_macos/macos/Classes/FlutterSecureStorage.swift
+++ b/flutter_secure_storage_macos/macos/Classes/FlutterSecureStorage.swift
@@ -74,8 +74,8 @@ class FlutterSecureStorage{
         }
     }
     
-    internal func readAll(groupId: String?, accountName: String?, synchronizable: Bool?) -> FlutterSecureStorageResponse {
-        var keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: nil, returnData: true)
+    internal func readAll(groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
+        var keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: true)
         
         keychainQuery[kSecMatchLimit] = kSecMatchLimitAll
         keychainQuery[kSecReturnAttributes] = true

--- a/flutter_secure_storage_macos/macos/Classes/FlutterSecureStorage.swift
+++ b/flutter_secure_storage_macos/macos/Classes/FlutterSecureStorage.swift
@@ -74,8 +74,8 @@ class FlutterSecureStorage{
         }
     }
     
-    internal func readAll(groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
-        var keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: true)
+    internal func readAll(groupId: String?, accountName: String?, synchronizable: Bool?) -> FlutterSecureStorageResponse {
+        var keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: nil, returnData: true)
         
         keychainQuery[kSecMatchLimit] = kSecMatchLimitAll
         keychainQuery[kSecReturnAttributes] = true

--- a/flutter_secure_storage_macos/macos/Classes/FlutterSecureStoragePlugin.swift
+++ b/flutter_secure_storage_macos/macos/Classes/FlutterSecureStoragePlugin.swift
@@ -99,7 +99,7 @@ public class FlutterSecureStoragePlugin: NSObject, FlutterPlugin {
     
     private func readAll(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
-        let response = flutterSecureStorageManager.readAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
+        let response = flutterSecureStorageManager.readAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable)
         
         handleResponse(response, result)
     }

--- a/flutter_secure_storage_macos/macos/Classes/FlutterSecureStoragePlugin.swift
+++ b/flutter_secure_storage_macos/macos/Classes/FlutterSecureStoragePlugin.swift
@@ -99,7 +99,7 @@ public class FlutterSecureStoragePlugin: NSObject, FlutterPlugin {
     
     private func readAll(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
-        let response = flutterSecureStorageManager.readAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable)
+        let response = flutterSecureStorageManager.readAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
         
         handleResponse(response, result)
     }

--- a/flutter_secure_storage_macos/macos/Classes/FlutterSecureStoragePlugin.swift
+++ b/flutter_secure_storage_macos/macos/Classes/FlutterSecureStoragePlugin.swift
@@ -92,7 +92,7 @@ public class FlutterSecureStoragePlugin: NSObject, FlutterPlugin {
     
     private func deleteAll(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
-        let response = flutterSecureStorageManager.deleteAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable)
+        let response = flutterSecureStorageManager.deleteAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
         
         handleResponse(response, result)
     }


### PR DESCRIPTION
As described in https://github.com/mogol/flutter_secure_storage/issues/709#issuecomment-2114743623 I was having issues getting values from my keychain using `await secureStorage.readAll()`, however, `await secureStorage.read(key: 'foo')` worked fine. Additionally, @feinstein reported similar issues with `deleteAll` in #720 

It seems that somehow the `accessibility` for `readAll` and `deleteAll` was explicitly (possibly deliberately?) set to `nil`  in #602 

- ### iOS
  - `accessibility` is not passed in `readAll` https://github.com/mogol/flutter_secure_storage/blob/eaccd9fb88effab9d3274c51cc91a3bc5886d8fd/flutter_secure_storage/ios/Classes/FlutterSecureStorage.swift#L75 whereas it's passed in `read` https://github.com/mogol/flutter_secure_storage/blob/eaccd9fb88effab9d3274c51cc91a3bc5886d8fd/flutter_secure_storage/ios/Classes/FlutterSecureStorage.swift#L105
  - `deleteAll` is also affected (reported in #720) https://github.com/mogol/flutter_secure_storage/blob/eaccd9fb88effab9d3274c51cc91a3bc5886d8fd/flutter_secure_storage/ios/Classes/FlutterSecureStorage.swift#L128 opposed to `delete` https://github.com/mogol/flutter_secure_storage/blob/eaccd9fb88effab9d3274c51cc91a3bc5886d8fd/flutter_secure_storage/ios/Classes/FlutterSecureStorage.swift#L140

- ### macOS
  - The same is true for the `macOS` package's `readAll`
https://github.com/mogol/flutter_secure_storage/blob/eaccd9fb88effab9d3274c51cc91a3bc5886d8fd/flutter_secure_storage_macos/macos/Classes/FlutterSecureStorage.swift#L78 vs `read` https://github.com/mogol/flutter_secure_storage/blob/eaccd9fb88effab9d3274c51cc91a3bc5886d8fd/flutter_secure_storage_macos/macos/Classes/FlutterSecureStorage.swift#L108
  - as is `deleteAll` (reported in #720) https://github.com/mogol/flutter_secure_storage/blob/eaccd9fb88effab9d3274c51cc91a3bc5886d8fd/flutter_secure_storage_macos/macos/Classes/FlutterSecureStorage.swift#L131 compared to `delete` https://github.com/mogol/flutter_secure_storage/blob/eaccd9fb88effab9d3274c51cc91a3bc5886d8fd/flutter_secure_storage_macos/macos/Classes/FlutterSecureStorage.swift#L143

After I've passed `accessibility` to `readAll` and `deleteAll` just like it's passed in `read` and `delete` I was able to get data from my keychain using `readAll` and delete it using `deleteAll`.

Please see the tests mentioned in https://github.com/mogol/flutter_secure_storage/issues/709#issuecomment-2114743623 how to replicate / test this.

---

- Relates to #602
- Fixes #709, specifically https://github.com/mogol/flutter_secure_storage/issues/709#issuecomment-2114743623
- Fixes #720

---

[Further reading](https://developer.apple.com/documentation/security/keychain_services/keychain_items/restricting_keychain_item_accessibility) (Apple documentation)