### PR TITLE
feat: Support for wrap and unwrap key on web platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,22 @@ Please see:
 - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
 - https://www.netsparker.com/blog/web-security/http-security-headers/
 
+#### application-specific key option
+
+On the web, all keys are stored in LocalStorage. flutter_secure_storage has an option for the web to wrap this stored key with an application-specific key to make it more difficult to analyze.
+
+```dart
+final _storage = const FlutterSecureStorage(
+  webOptions: WebOptions(
+    wrapKey: '${your_application_specific_key}',
+    wrapKeyIv: '${your_application_specific_iv}',
+  ),
+);
+```
+
+This option encrypts the key stored in LocalStorage with [WebCrypto wrapKey](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/wrapKey). It is decrypted with [WebCrypto unwrapKey](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/unwrapKey) when used.
+Generating and managing application-specific keys requires careful attention from developers. See (https://github.com/mogol/flutter_secure_storage/issues/726) for more information.
+
 ### Configure Linux Version
 
 You need `libsecret-1-dev` and `libjsoncpp-dev` on your machine to build the project, and `libsecret-1-0` and `libjsoncpp1` to run the application (add it as a dependency after packaging your app). If you using snapcraft to build the project use the following

--- a/flutter_secure_storage/lib/options/web_options.dart
+++ b/flutter_secure_storage/lib/options/web_options.dart
@@ -5,16 +5,22 @@ class WebOptions extends Options {
   const WebOptions({
     this.dbName = 'FlutterEncryptedStorage',
     this.publicKey = 'FlutterSecureStorage',
+    this.wrapKey = '',
+    this.wrapKeyIv = '',
   });
 
   static const WebOptions defaultOptions = WebOptions();
 
   final String dbName;
   final String publicKey;
+  final String wrapKey;
+  final String wrapKeyIv;
 
   @override
   Map<String, String> toMap() => <String, String>{
         'dbName': dbName,
         'publicKey': publicKey,
+        'wrapKey': wrapKey,
+        'wrapKeyIv': wrapKeyIv,
       };
 }


### PR DESCRIPTION
close #726

I have added a function to wrap a key stored in LocalStorage using an application specific encryption key. This function uses the WebCrypto API [wrapKey](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/wrapKey) and [unwrapKey](https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/unwrapKey).

The wrapping key can be generated by the following snippet.

```javascript
async function main() {
  const iv = new Uint8Array(12);
  window.crypto.getRandomValues(iv);

  const key = await window.crypto.subtle.generateKey(
    {
      name: "AES-GCM",
      length: 256,
      iv: iv,
    },
    true,
    ["wrapKey", "unwrapKey"]
  );

  const jsonWebKeyBuffer = await window.crypto.subtle.exportKey("raw", key);
  const jsonWebKey = new Uint8Array(jsonWebKeyBuffer);

  console.log("---iv---");
  const base64Iv = btoa(String.fromCharCode.apply(null, iv));
  console.log(base64Iv);

  console.log("---wrapping key---");
  const wrappingKey = btoa(String.fromCharCode.apply(null, jsonWebKey));
  console.log(wrappingKey);
}

main();
```

To use the function, set a value to the option as follows.

```dart
final _storage = const FlutterSecureStorage(
  // This is example key and iv
  webOptions: WebOptions(
    wrapKey: 'FQQloR/Xwv1BcJOc3VrcxlJatdA/C+n6+v7pFJC0GBs=',
    wrapKeyIv: 'YTVC7K5dOsQTjk+z',
  ),
);
```