### PR TITLE
Add useDataProtectionKeyChain parameter to macOS options

### DIFF
--- a/flutter_secure_storage/lib/options/macos_options.dart
+++ b/flutter_secure_storage/lib/options/macos_options.dart
@@ -7,7 +7,9 @@ class MacOsOptions extends AppleOptions {
     String? accountName = AppleOptions.defaultAccountName,
     KeychainAccessibility accessibility = KeychainAccessibility.unlocked,
     bool synchronizable = false,
-  }) : super(
+    bool useDataProtectionKeyChain = true,
+  })  : _useDataProtectionKeyChain = useDataProtectionKeyChain,
+        super(
           groupId: groupId,
           accountName: accountName,
           accessibility: accessibility,
@@ -16,16 +18,27 @@ class MacOsOptions extends AppleOptions {
 
   static const MacOsOptions defaultOptions = MacOsOptions();
 
+  final bool _useDataProtectionKeyChain;
+
   MacOsOptions copyWith({
     String? groupId,
     String? accountName,
     KeychainAccessibility? accessibility,
     bool? synchronizable,
+    bool? useDataProtectionKeyChain,
   }) =>
       MacOsOptions(
         groupId: groupId ?? _groupId,
         accountName: accountName ?? _accountName,
         accessibility: accessibility ?? _accessibility,
         synchronizable: synchronizable ?? _synchronizable,
+        useDataProtectionKeyChain:
+            useDataProtectionKeyChain ?? _useDataProtectionKeyChain,
       );
+
+  @override
+  Map<String, String> toMap() => <String, String>{
+        ...super.toMap(),
+        'useDataProtectionKeyChain': '$_useDataProtectionKeyChain',
+      };
 }

--- a/flutter_secure_storage_macos/macos/Classes/FlutterSecureStorage.swift
+++ b/flutter_secure_storage_macos/macos/Classes/FlutterSecureStorage.swift
@@ -29,13 +29,14 @@ class FlutterSecureStorage{
         }
     }
 
-    private func baseQuery(key: String?, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?, useDataProtectionKeyChain: Bool?, returnData: Bool?) -> Dictionary<CFString, Any> {
+    private func baseQuery(key: String?, groupId: String?, accountName: String?, synchronizable: Bool, accessibility: String?, useDataProtectionKeyChain: Bool, returnData: Bool?) -> Dictionary<CFString, Any> {
         var keychainQuery: [CFString: Any] = [
             kSecClass : kSecClassGenericPassword,
             kSecAttrAccessible : parseAccessibleAttr(accessibility: accessibility),
+            kSecAttrSynchronizable : synchronizable,
         ]
         if #available(macOS 10.15, *) {
-            keychainQuery[kSecUseDataProtectionKeychain] = useDataProtectionKeyChain ?? true
+            keychainQuery[kSecUseDataProtectionKeychain] = useDataProtectionKeyChain
         }
 
         if (key != nil) {
@@ -50,17 +51,13 @@ class FlutterSecureStorage{
             keychainQuery[kSecAttrService] = accountName
         }
 
-        if (synchronizable != nil) {
-            keychainQuery[kSecAttrSynchronizable] = synchronizable
-        }
-
         if (returnData != nil) {
             keychainQuery[kSecReturnData] = returnData
         }
         return keychainQuery
     }
 
-    internal func containsKey(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?, useDataProtectionKeyChain: Bool?) -> Result<Bool, OSSecError> {
+    internal func containsKey(key: String, groupId: String?, accountName: String?, synchronizable: Bool, accessibility: String?, useDataProtectionKeyChain: Bool) -> Result<Bool, OSSecError> {
         let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, useDataProtectionKeyChain: useDataProtectionKeyChain, returnData: false)
 
         let status = SecItemCopyMatching(keychainQuery as CFDictionary, nil)
@@ -74,7 +71,7 @@ class FlutterSecureStorage{
         }
     }
 
-    internal func readAll(groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?, useDataProtectionKeyChain: Bool?) -> FlutterSecureStorageResponse {
+    internal func readAll(groupId: String?, accountName: String?, synchronizable: Bool, accessibility: String?, useDataProtectionKeyChain: Bool) -> FlutterSecureStorageResponse {
         var keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, useDataProtectionKeyChain: useDataProtectionKeyChain, returnData: true)
 
         keychainQuery[kSecMatchLimit] = kSecMatchLimitAll
@@ -104,7 +101,7 @@ class FlutterSecureStorage{
         return FlutterSecureStorageResponse(status: status, value: results)
     }
 
-    internal func read(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?, useDataProtectionKeyChain: Bool?) -> FlutterSecureStorageResponse {
+    internal func read(key: String, groupId: String?, accountName: String?, synchronizable: Bool, accessibility: String?, useDataProtectionKeyChain: Bool) -> FlutterSecureStorageResponse {
         let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, useDataProtectionKeyChain: useDataProtectionKeyChain, returnData: true)
 
         var ref: AnyObject?
@@ -127,7 +124,7 @@ class FlutterSecureStorage{
         return FlutterSecureStorageResponse(status: status, value: value)
     }
 
-    internal func deleteAll(groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?, useDataProtectionKeyChain: Bool?) -> FlutterSecureStorageResponse {
+    internal func deleteAll(groupId: String?, accountName: String?, synchronizable: Bool, accessibility: String?, useDataProtectionKeyChain: Bool) -> FlutterSecureStorageResponse {
         let keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, useDataProtectionKeyChain: useDataProtectionKeyChain, returnData: nil)
         let status = SecItemDelete(keychainQuery as CFDictionary)
 
@@ -139,7 +136,7 @@ class FlutterSecureStorage{
         return FlutterSecureStorageResponse(status: status, value: nil)
     }
 
-    internal func delete(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?, useDataProtectionKeyChain: Bool?) -> FlutterSecureStorageResponse {
+    internal func delete(key: String, groupId: String?, accountName: String?, synchronizable: Bool, accessibility: String?, useDataProtectionKeyChain: Bool) -> FlutterSecureStorageResponse {
         let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, useDataProtectionKeyChain: useDataProtectionKeyChain, returnData: true)
         let status = SecItemDelete(keychainQuery as CFDictionary)
 
@@ -151,7 +148,7 @@ class FlutterSecureStorage{
         return FlutterSecureStorageResponse(status: status, value: nil)
     }
 
-    internal func write(key: String, value: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?, useDataProtectionKeyChain: Bool?) -> FlutterSecureStorageResponse {
+    internal func write(key: String, value: String, groupId: String?, accountName: String?, synchronizable: Bool, accessibility: String?, useDataProtectionKeyChain: Bool) -> FlutterSecureStorageResponse {
         var keyExists: Bool = false
 
     	switch containsKey(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, useDataProtectionKeyChain: useDataProtectionKeyChain) {
@@ -174,7 +171,7 @@ class FlutterSecureStorage{
                 kSecAttrSynchronizable: synchronizable
             ]
             if #available(macOS 10.15, *) {
-                update[kSecUseDataProtectionKeychain] = useDataProtectionKeyChain ?? true
+                update[kSecUseDataProtectionKeychain] = useDataProtectionKeyChain
             }
 
             let status = SecItemUpdate(keychainQuery as CFDictionary, update as CFDictionary)
@@ -184,7 +181,7 @@ class FlutterSecureStorage{
             keychainQuery[kSecValueData] = value.data(using: String.Encoding.utf8)
             keychainQuery[kSecAttrAccessible] = attrAccessible
             if #available(macOS 10.15, *) {
-                keychainQuery[kSecUseDataProtectionKeychain] = useDataProtectionKeyChain ?? true
+                keychainQuery[kSecUseDataProtectionKeychain] = useDataProtectionKeyChain
             }
 
             let status = SecItemAdd(keychainQuery as CFDictionary, nil)

--- a/flutter_secure_storage_macos/macos/Classes/FlutterSecureStorage.swift
+++ b/flutter_secure_storage_macos/macos/Classes/FlutterSecureStorage.swift
@@ -12,7 +12,7 @@ class FlutterSecureStorage{
         guard let accessibility = accessibility else {
             return kSecAttrAccessibleWhenUnlocked
         }
-        
+
         switch accessibility {
         case "passcode":
             return kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly
@@ -29,40 +29,40 @@ class FlutterSecureStorage{
         }
     }
 
-    private func baseQuery(key: String?, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?, returnData: Bool?) -> Dictionary<CFString, Any> {
+    private func baseQuery(key: String?, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?, useDataProtectionKeyChain: Bool?, returnData: Bool?) -> Dictionary<CFString, Any> {
         var keychainQuery: [CFString: Any] = [
             kSecClass : kSecClassGenericPassword,
             kSecAttrAccessible : parseAccessibleAttr(accessibility: accessibility),
         ]
         if #available(macOS 10.15, *) {
-            keychainQuery[kSecUseDataProtectionKeychain] = true
+            keychainQuery[kSecUseDataProtectionKeychain] = useDataProtectionKeyChain ?? true
         }
-        
+
         if (key != nil) {
             keychainQuery[kSecAttrAccount] = key
         }
-        
+
         if (groupId != nil) {
             keychainQuery[kSecAttrAccessGroup] = groupId
         }
-        
+
         if (accountName != nil) {
             keychainQuery[kSecAttrService] = accountName
         }
-        
+
         if (synchronizable != nil) {
             keychainQuery[kSecAttrSynchronizable] = synchronizable
         }
-        
+
         if (returnData != nil) {
             keychainQuery[kSecReturnData] = returnData
         }
         return keychainQuery
     }
-    
-    internal func containsKey(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> Result<Bool, OSSecError> {  
-        let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: false)
-        
+
+    internal func containsKey(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?, useDataProtectionKeyChain: Bool?) -> Result<Bool, OSSecError> {
+        let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, useDataProtectionKeyChain: useDataProtectionKeyChain, returnData: false)
+
         let status = SecItemCopyMatching(keychainQuery as CFDictionary, nil)
         switch status {
         case errSecSuccess:
@@ -73,26 +73,26 @@ class FlutterSecureStorage{
             return .failure(OSSecError(status: status))
         }
     }
-    
-    internal func readAll(groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
-        var keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: true)
-        
+
+    internal func readAll(groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?, useDataProtectionKeyChain: Bool?) -> FlutterSecureStorageResponse {
+        var keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, useDataProtectionKeyChain: useDataProtectionKeyChain, returnData: true)
+
         keychainQuery[kSecMatchLimit] = kSecMatchLimitAll
         keychainQuery[kSecReturnAttributes] = true
-        
+
         var ref: AnyObject?
         let status = SecItemCopyMatching(
             keychainQuery as CFDictionary,
             &ref
         )
-        
+
         if (status == errSecItemNotFound) {
             // readAll() returns all elements, so return nil if the items does not exist
             return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
         }
-        
+
         var results: [String: String] = [:]
-        
+
         if (status == noErr) {
             (ref as! NSArray).forEach { item in
                 let key: String = (item as! NSDictionary)[kSecAttrAccount] as! String
@@ -100,37 +100,37 @@ class FlutterSecureStorage{
                 results[key] = value
             }
         }
-        
+
         return FlutterSecureStorageResponse(status: status, value: results)
     }
-    
-    internal func read(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
-        let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: true)
-        
+
+    internal func read(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?, useDataProtectionKeyChain: Bool?) -> FlutterSecureStorageResponse {
+        let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, useDataProtectionKeyChain: useDataProtectionKeyChain, returnData: true)
+
         var ref: AnyObject?
         let status = SecItemCopyMatching(
             keychainQuery as CFDictionary,
             &ref
         )
-        
+
         // Return nil if the key is not found
         if (status == errSecItemNotFound) {
             return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
         }
-        
+
         var value: String? = nil
-        
+
         if (status == noErr) {
             value = String(data: ref as! Data, encoding: .utf8)
         }
 
         return FlutterSecureStorageResponse(status: status, value: value)
     }
-    
-    internal func deleteAll(groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
-        let keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: nil)
+
+    internal func deleteAll(groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?, useDataProtectionKeyChain: Bool?) -> FlutterSecureStorageResponse {
+        let keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, useDataProtectionKeyChain: useDataProtectionKeyChain, returnData: nil)
         let status = SecItemDelete(keychainQuery as CFDictionary)
-        
+
         if (status == errSecItemNotFound) {
             // deleteAll() deletes all items, so return nil if the items does not exist
             return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
@@ -138,23 +138,23 @@ class FlutterSecureStorage{
 
         return FlutterSecureStorageResponse(status: status, value: nil)
     }
-    
-    internal func delete(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
-        let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: true)
+
+    internal func delete(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?, useDataProtectionKeyChain: Bool?) -> FlutterSecureStorageResponse {
+        let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, useDataProtectionKeyChain: useDataProtectionKeyChain, returnData: true)
         let status = SecItemDelete(keychainQuery as CFDictionary)
-        
+
         // Return nil if the key is not found
         if (status == errSecItemNotFound) {
             return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
         }
-        
+
         return FlutterSecureStorageResponse(status: status, value: nil)
     }
-    
-    internal func write(key: String, value: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {        
+
+    internal func write(key: String, value: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?, useDataProtectionKeyChain: Bool?) -> FlutterSecureStorageResponse {
         var keyExists: Bool = false
 
-    	switch containsKey(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility) {
+    	switch containsKey(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, useDataProtectionKeyChain: useDataProtectionKeyChain) {
         case .success(let exists):
             keyExists = exists
             break;
@@ -163,10 +163,10 @@ class FlutterSecureStorage{
         }
 
         let attrAccessible = parseAccessibleAttr(accessibility: accessibility);
-        var keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: nil)
+        var keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, useDataProtectionKeyChain: useDataProtectionKeyChain, returnData: nil)
 
         if (keyExists) {
-            
+
 
             var update: [CFString: Any?] = [
                 kSecValueData: value.data(using: String.Encoding.utf8),
@@ -174,24 +174,24 @@ class FlutterSecureStorage{
                 kSecAttrSynchronizable: synchronizable
             ]
             if #available(macOS 10.15, *) {
-                update[kSecUseDataProtectionKeychain] = true
+                update[kSecUseDataProtectionKeychain] = useDataProtectionKeyChain ?? true
             }
 
             let status = SecItemUpdate(keychainQuery as CFDictionary, update as CFDictionary)
-            
+
             return FlutterSecureStorageResponse(status: status, value: nil)
         } else {
             keychainQuery[kSecValueData] = value.data(using: String.Encoding.utf8)
             keychainQuery[kSecAttrAccessible] = attrAccessible
             if #available(macOS 10.15, *) {
-                keychainQuery[kSecUseDataProtectionKeychain] = true
+                keychainQuery[kSecUseDataProtectionKeychain] = useDataProtectionKeyChain ?? true
             }
-            
+
             let status = SecItemAdd(keychainQuery as CFDictionary, nil)
 
             return FlutterSecureStorageResponse(status: status, value: nil)
         }
-    }    
+    }
 }
 
 struct FlutterSecureStorageResponse {

--- a/flutter_secure_storage_macos/macos/Classes/FlutterSecureStoragePlugin.swift
+++ b/flutter_secure_storage_macos/macos/Classes/FlutterSecureStoragePlugin.swift
@@ -52,7 +52,7 @@ public class FlutterSecureStoragePlugin: NSObject, FlutterPlugin {
             return
         }
         
-        let response = flutterSecureStorageManager.read(key: values.key!, groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
+        let response = flutterSecureStorageManager.read(key: values.key!, groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility, useDataProtectionKeyChain: values.useDataProtectionKeyChain)
         handleResponse(response, result)
     }
     
@@ -73,7 +73,7 @@ public class FlutterSecureStoragePlugin: NSObject, FlutterPlugin {
             return
         }
         
-        let response = flutterSecureStorageManager.write(key: values.key!, value: values.value!, groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
+        let response = flutterSecureStorageManager.write(key: values.key!, value: values.value!, groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility, useDataProtectionKeyChain: values.useDataProtectionKeyChain)
         
         handleResponse(response, result)
     }
@@ -85,21 +85,21 @@ public class FlutterSecureStoragePlugin: NSObject, FlutterPlugin {
             return
         }
         
-        let response = flutterSecureStorageManager.delete(key: values.key!, groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
+        let response = flutterSecureStorageManager.delete(key: values.key!, groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility, useDataProtectionKeyChain: values.useDataProtectionKeyChain)
         
         handleResponse(response, result)
     }
     
     private func deleteAll(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
-        let response = flutterSecureStorageManager.deleteAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
+        let response = flutterSecureStorageManager.deleteAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility, useDataProtectionKeyChain: values.useDataProtectionKeyChain)
         
         handleResponse(response, result)
     }
     
     private func readAll(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
-        let response = flutterSecureStorageManager.readAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
+        let response = flutterSecureStorageManager.readAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility, useDataProtectionKeyChain: values.useDataProtectionKeyChain)
         
         handleResponse(response, result)
     }
@@ -110,7 +110,7 @@ public class FlutterSecureStoragePlugin: NSObject, FlutterPlugin {
             result(FlutterError.init(code: "Missing Parameter", message: "containsKey requires key parameter", details: nil))
         }
         
-        let response = flutterSecureStorageManager.containsKey(key: values.key!, groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
+        let response = flutterSecureStorageManager.containsKey(key: values.key!, groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility, useDataProtectionKeyChain: values.useDataProtectionKeyChain)
         
         switch response {
         case .success(let exists):
@@ -136,8 +136,10 @@ public class FlutterSecureStoragePlugin: NSObject, FlutterPlugin {
         let accountName = options["accountName"] as? String
         let groupId = options["groupId"] as? String
         let synchronizableString = options["synchronizable"] as? String
+        let useDataProtectionKeyChainString = options["useDataProtectionKeyChain"] as? String
         
         let synchronizable: Bool = synchronizableString != nil ? Bool(synchronizableString!)! : false
+        let useDataProtectionKeyChain: Bool = useDataProtectionKeyChainString != nil ? Bool(useDataProtectionKeyChainString!)! : true
         
         let key = arguments["key"] as? String
         let accessibility = options["accessibility"] as? String
@@ -147,8 +149,9 @@ public class FlutterSecureStoragePlugin: NSObject, FlutterPlugin {
             accountName: accountName,
             groupId: groupId,
             synchronizable: synchronizable,
-            accessibility: accessibility, 
-            key: key, 
+            useDataProtectionKeyChain: useDataProtectionKeyChain,
+            accessibility: accessibility,
+            key: key,
             value: value
         )
     }
@@ -176,6 +179,7 @@ public class FlutterSecureStoragePlugin: NSObject, FlutterPlugin {
         var accountName: String?
         var groupId: String?
         var synchronizable: Bool?
+        var useDataProtectionKeyChain: Bool?
         var accessibility: String?
         var key: String?
         var value: String?

--- a/flutter_secure_storage_macos/macos/Classes/FlutterSecureStoragePlugin.swift
+++ b/flutter_secure_storage_macos/macos/Classes/FlutterSecureStoragePlugin.swift
@@ -178,8 +178,8 @@ public class FlutterSecureStoragePlugin: NSObject, FlutterPlugin {
     struct FlutterSecureStorageRequest {
         var accountName: String?
         var groupId: String?
-        var synchronizable: Bool?
-        var useDataProtectionKeyChain: Bool?
+        var synchronizable: Bool
+        var useDataProtectionKeyChain: Bool
         var accessibility: String?
         var key: String?
         var value: String?


### PR DESCRIPTION
This pull request aims to enable the optional use of the "classic" macOS keychain. This is done by adding the `useDataProtectionKeyChain` parameter to the macOS options. It defaults to `true` so the default behavior does not change.

The reason for adding this is that the data protection keychain while being more secure has two drawbacks:
1. The entries cannot be accessed with the `security` command line tool
2. The data protection key chain requires an entitlement, which in turn requires the app to be signed. So using this plugin for an unsigned, internal macOS app is not possible without this fix.

I have created 2 commits. The first implements the change described above. The second commit makes the `synchronizable` and `useDataProtectionKeyChain` parameters inside the macOS implementation non-nullable, as they are always set by the code. This simplifies the code as the unnecessary null checks can be removed. If you prefer to keep the nullable booleans or would like two separate pull request, and can revert the second commit.