### PR TITLE
Fix for issue #711: The specified item already exists in the keychain, iOS Code -25299, -25300

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 A Flutter plugin to store data in secure storage:
 
 - [Keychain](https://developer.apple.com/library/content/documentation/Security/Conceptual/keychainServConcepts/01introduction/introduction.html#//apple_ref/doc/uid/TP30000897-CH203-TP1) is used for iOS
-- AES encryption is used for Android. AES secret key is encrypted with RSA and RSA key is stored in [KeyStore](https://developer.android.com/training/articles/keystore.html).   
-  By default following algorithms are used for AES and secret key encryption: AES/CBC/PKCS7Padding and RSA/ECB/PKCS1Padding  
-  From Android 6 you can use newer, recommended algoritms:  
-  AES/GCM/NoPadding and RSA/ECB/OAEPWithSHA-256AndMGF1Padding  
+- AES encryption is used for Android. AES secret key is encrypted with RSA and RSA key is stored in [KeyStore](https://developer.android.com/training/articles/keystore.html).
+  By default following algorithms are used for AES and secret key encryption: AES/CBC/PKCS7Padding and RSA/ECB/PKCS1Padding
+  From Android 6 you can use newer, recommended algoritms:
+  AES/GCM/NoPadding and RSA/ECB/OAEPWithSHA-256AndMGF1Padding
   You can set them in Android options like so:
 ```dart
   AndroidOptions _getAndroidOptions() => const AndroidOptions(
@@ -56,7 +56,7 @@ If not present already, please call WidgetsFlutterBinding.ensureInitialized() in
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 // Create storage
-final storage = new FlutterSecureStorage();
+final storage = FlutterSecureStorage();
 
 // Read value
 String value = await storage.read(key: key);

--- a/flutter_secure_storage/CHANGELOG.md
+++ b/flutter_secure_storage/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 9.2.3
+* [iOS] Fix for issue #711: The specified item already exists in the keychain.
+
 ## 9.2.2
 [iOS, macOS] Fixed an issue which caused the readAll and deleteAll to not work properly.
 
@@ -13,7 +16,7 @@ New Features:
 Bugs Fixed:
 * [iOS] Return nil on iOS read if key is not found
 * [macOS] Also set kSecUseDataProtectionKeychain on read for macos.
- 
+
 ## 9.1.1
 Reverts new feature because of breaking changes.
 * [iOS, macOS] Added isProtectedDataAvailable, A boolean value that indicates whether content protection is active.

--- a/flutter_secure_storage/README.md
+++ b/flutter_secure_storage/README.md
@@ -2,7 +2,7 @@
 
 ## Note: usage of encryptedSharedPreference
 When using the `encryptedSharedPreferences` parameter on Android, make sure to pass the option to the
-constructor instead of the function like so: 
+constructor instead of the function like so:
 ```dart
   AndroidOptions _getAndroidOptions() => const AndroidOptions(
         encryptedSharedPreferences: true,
@@ -22,7 +22,7 @@ A Flutter plugin to store data in secure storage:
   AndroidOptions _getAndroidOptions() => const AndroidOptions(
         encryptedSharedPreferences: true,
       );
-```    
+```
   For more information see the example app.
 - [`libsecret`](https://wiki.gnome.org/Projects/Libsecret) is used for Linux.
 
@@ -34,7 +34,7 @@ _Note_ KeyStore was introduced in Android 4.3 (API level 18). The plugin wouldn'
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 // Create storage
-final storage = new FlutterSecureStorage();
+final storage = FlutterSecureStorage();
 
 // Read value
 String value = await storage.read(key: key);

--- a/flutter_secure_storage/ios/Classes/FlutterSecureStorage.swift
+++ b/flutter_secure_storage/ios/Classes/FlutterSecureStorage.swift
@@ -7,12 +7,12 @@
 
 import Foundation
 
-class FlutterSecureStorage{
+class FlutterSecureStorage {
     private func parseAccessibleAttr(accessibility: String?) -> CFString {
         guard let accessibility = accessibility else {
             return kSecAttrAccessibleWhenUnlocked
         }
-        
+
         switch accessibility {
         case "passcode":
             return kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly
@@ -31,35 +31,39 @@ class FlutterSecureStorage{
 
     private func baseQuery(key: String?, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?, returnData: Bool?) -> Dictionary<CFString, Any> {
         var keychainQuery: [CFString: Any] = [
-            kSecClass : kSecClassGenericPassword,
-            kSecAttrAccessible : parseAccessibleAttr(accessibility: accessibility),
+            kSecClass : kSecClassGenericPassword
         ]
-        
+
+        if (accessibility != nil) {
+            keychainQuery[kSecAttrAccessible] = parseAccessibleAttr(accessibility: accessibility)
+        }
+
         if (key != nil) {
             keychainQuery[kSecAttrAccount] = key
         }
-        
+
         if (groupId != nil) {
             keychainQuery[kSecAttrAccessGroup] = groupId
         }
-        
+
         if (accountName != nil) {
             keychainQuery[kSecAttrService] = accountName
         }
-        
+
         if (synchronizable != nil) {
             keychainQuery[kSecAttrSynchronizable] = synchronizable
         }
-        
+
         if (returnData != nil) {
             keychainQuery[kSecReturnData] = returnData
         }
         return keychainQuery
     }
-    
-    internal func containsKey(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> Result<Bool, OSSecError> {  
-        let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: false)
-        
+
+    internal func containsKey(key: String, groupId: String?, accountName: String?) -> Result<Bool, OSSecError> {
+        // The accessibility and synchronisable parameters have no influence on uniqueness.
+        let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: nil, accessibility: nil, returnData: false)
+
         let status = SecItemCopyMatching(keychainQuery as CFDictionary, nil)
         switch status {
         case errSecSuccess:
@@ -70,26 +74,26 @@ class FlutterSecureStorage{
             return .failure(OSSecError(status: status))
         }
     }
-    
+
     internal func readAll(groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
         var keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: true)
-        
+
         keychainQuery[kSecMatchLimit] = kSecMatchLimitAll
         keychainQuery[kSecReturnAttributes] = true
-        
+
         var ref: AnyObject?
         let status = SecItemCopyMatching(
             keychainQuery as CFDictionary,
             &ref
         )
-        
+
         if (status == errSecItemNotFound) {
             // readAll() returns all elements, so return nil if the items does not exist
             return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
         }
 
         var results: [String: String] = [:]
-        
+
         if (status == noErr) {
             (ref as! NSArray).forEach { item in
                 let key: String = (item as! NSDictionary)[kSecAttrAccount] as! String
@@ -97,13 +101,13 @@ class FlutterSecureStorage{
                 results[key] = value
             }
         }
-        
+
         return FlutterSecureStorageResponse(status: status, value: results)
     }
-    
+
     internal func read(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
         let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: true)
-        
+
         var ref: AnyObject?
         let status = SecItemCopyMatching(
             keychainQuery as CFDictionary,
@@ -114,73 +118,80 @@ class FlutterSecureStorage{
         if (status == errSecItemNotFound) {
             return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
         }
-        
+
         var value: String? = nil
-        
+
         if (status == noErr) {
             value = String(data: ref as! Data, encoding: .utf8)
         }
 
         return FlutterSecureStorageResponse(status: status, value: value)
     }
-    
-    internal func deleteAll(groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
-        let keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: nil)
+
+    internal func deleteAll(groupId: String?, accountName: String?) -> FlutterSecureStorageResponse {
+        let keychainQuery = baseQuery(key: nil, groupId: groupId, accountName: accountName, synchronizable: nil, accessibility: nil, returnData: nil)
         let status = SecItemDelete(keychainQuery as CFDictionary)
-        
+
         if (status == errSecItemNotFound) {
             // deleteAll() deletes all items, so return nil if the items does not exist
             return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
         }
-        
+
         return FlutterSecureStorageResponse(status: status, value: nil)
     }
-    
-    internal func delete(key: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
-        let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: true)
+
+    internal func delete(key: String, groupId: String?, accountName: String?) -> FlutterSecureStorageResponse {
+        let keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: nil, accessibility: nil, returnData: true)
         let status = SecItemDelete(keychainQuery as CFDictionary)
 
         // Return nil if the key is not found
         if (status == errSecItemNotFound) {
             return FlutterSecureStorageResponse(status: errSecSuccess, value: nil)
         }
-        
+
         return FlutterSecureStorageResponse(status: status, value: nil)
     }
-    
-    internal func write(key: String, value: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {        
+
+    internal func write(key: String, value: String, groupId: String?, accountName: String?, synchronizable: Bool?, accessibility: String?) -> FlutterSecureStorageResponse {
         var keyExists: Bool = false
 
-    	switch containsKey(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility) {
-        case .success(let exists):
-            keyExists = exists
-            break;
-        case .failure(let err):
-            return FlutterSecureStorageResponse(status: err.status, value: nil)
+        // Check if the key exists but without accessibility and synchronisable.
+        // These parameters have no effect on the uniqueness of the key.
+    	switch containsKey(key: key, groupId: groupId, accountName: accountName) {
+            case .success(let exists):
+                keyExists = exists
+                break;
+            case .failure(let err):
+                return FlutterSecureStorageResponse(status: err.status, value: nil)
         }
 
         var keychainQuery = baseQuery(key: key, groupId: groupId, accountName: accountName, synchronizable: synchronizable, accessibility: accessibility, returnData: nil)
 
         if (keyExists) {
-            let attrAccessible = parseAccessibleAttr(accessibility: accessibility)
-            
+            // Entry exists, try to update it. Change of kSecAttrAccessible not possible via update.
             let update: [CFString: Any?] = [
                 kSecValueData: value.data(using: String.Encoding.utf8),
-                kSecAttrAccessible: attrAccessible,
                 kSecAttrSynchronizable: synchronizable
             ]
-            
-            let status = SecItemUpdate(keychainQuery as CFDictionary, update as CFDictionary)
-            
-            return FlutterSecureStorageResponse(status: status, value: nil)
-        } else {
-            keychainQuery[kSecValueData] = value.data(using: String.Encoding.utf8)
-            
-            let status = SecItemAdd(keychainQuery as CFDictionary, nil)
 
-            return FlutterSecureStorageResponse(status: status, value: nil)
+            let status = SecItemUpdate(keychainQuery as CFDictionary, update as CFDictionary)
+
+            if status == errSecSuccess {
+                return FlutterSecureStorageResponse(status: status, value: nil)
+            }
+
+            // Update failed, possibly due to different kSecAttrAccessible.
+            // Delete the entry and create a new one in the next step.
+            delete(key: key, groupId: groupId, accountName: accountName)
         }
-    }    
+
+        // Entry does not exist or was deleted, create a new entry.
+        keychainQuery[kSecValueData] = value.data(using: String.Encoding.utf8)
+
+        let status = SecItemAdd(keychainQuery as CFDictionary, nil)
+
+        return FlutterSecureStorageResponse(status: status, value: nil)
+    }
 }
 
 struct FlutterSecureStorageResponse {

--- a/flutter_secure_storage/ios/Classes/SwiftFlutterSecureStoragePlugin.swift
+++ b/flutter_secure_storage/ios/Classes/SwiftFlutterSecureStoragePlugin.swift
@@ -9,7 +9,7 @@ import Flutter
 import UIKit
 
 public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
-    
+
     private let flutterSecureStorageManager: FlutterSecureStorage = FlutterSecureStorage()
     private var secStoreAvailabilitySink: FlutterEventSink?
 
@@ -21,7 +21,7 @@ public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterSt
         registrar.addApplicationDelegate(instance)
         eventChannel.setStreamHandler(instance)
     }
-    
+
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         func handleResult(_ value: Any?) {
             DispatchQueue.main.async {
@@ -75,79 +75,79 @@ public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterSt
         self.secStoreAvailabilitySink = eventSink
         return nil
     }
-    
+
     public func onCancel(withArguments arguments: Any?) -> FlutterError? {
         self.secStoreAvailabilitySink = nil
         return nil
     }
-    
+
     private func read(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
         if (values.key == nil) {
             result(FlutterError.init(code: "Missing Parameter", message: "write requires key parameter", details: nil))
             return
         }
-        
+
         let response = flutterSecureStorageManager.read(key: values.key!, groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
         handleResponse(response, result)
     }
-    
+
     private func write(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         if (!((call.arguments as! [String : Any?])["value"] is String)){
             result(FlutterError.init(code: "Invalid Parameter", message: "key parameter must be String", details: nil))
             return;
         }
-        
+
         let values = parseCall(call)
         if (values.key == nil) {
             result(FlutterError.init(code: "Missing Parameter", message: "write requires key parameter", details: nil))
             return
         }
-        
+
         if (values.value == nil) {
             result(FlutterError.init(code: "Missing Parameter", message: "write requires value parameter", details: nil))
             return
         }
-        
+
         let response = flutterSecureStorageManager.write(key: values.key!, value: values.value!, groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
-        
+
         handleResponse(response, result)
     }
-    
+
     private func delete(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
         if (values.key == nil) {
             result(FlutterError.init(code: "Missing Parameter", message: "delete requires key parameter", details: nil))
             return
         }
-        
-        let response = flutterSecureStorageManager.delete(key: values.key!, groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
-        
+
+        let response = flutterSecureStorageManager.delete(key: values.key!, groupId: values.groupId, accountName: values.accountName)
+
         handleResponse(response, result)
     }
-    
+
     private func deleteAll(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
-        let response = flutterSecureStorageManager.deleteAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
-        
+        let response = flutterSecureStorageManager.deleteAll(groupId: values.groupId, accountName: values.accountName)
+
         handleResponse(response, result)
     }
-    
+
     private func readAll(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
         let response = flutterSecureStorageManager.readAll(groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
-        
+
         handleResponse(response, result)
     }
-    
+
     private func containsKey(_ call: FlutterMethodCall, _ result: @escaping FlutterResult) {
         let values = parseCall(call)
         if (values.key == nil) {
             result(FlutterError.init(code: "Missing Parameter", message: "containsKey requires key parameter", details: nil))
         }
-        
-        let response = flutterSecureStorageManager.containsKey(key: values.key!, groupId: values.groupId, accountName: values.accountName, synchronizable: values.synchronizable, accessibility: values.accessibility)
-        
+
+        let response = flutterSecureStorageManager.containsKey(key: values.key!, groupId: values.groupId, accountName: values.accountName)
+
         switch response {
         case .success(let exists):
             result(exists)
@@ -168,27 +168,27 @@ public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterSt
             break;
         }
     }
-    
+
     private func parseCall(_ call: FlutterMethodCall) -> FlutterSecureStorageRequest {
         let arguments = call.arguments as! [String : Any?]
         let options = arguments["options"] as! [String : Any?]
-        
+
         let accountName = options["accountName"] as? String
         let groupId = options["groupId"] as? String
         let synchronizableString = options["synchronizable"] as? String
-        
+
         let synchronizable: Bool = synchronizableString != nil ? Bool(synchronizableString!)! : false
-        
+
         let key = arguments["key"] as? String
         let accessibility = options["accessibility"] as? String
         let value = arguments["value"] as? String
-        
+
         return FlutterSecureStorageRequest(
             accountName: accountName,
             groupId: groupId,
             synchronizable: synchronizable,
-            accessibility: accessibility, 
-            key: key, 
+            accessibility: accessibility,
+            key: key,
             value: value
         )
     }
@@ -215,7 +215,7 @@ public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterSt
             result(response.value)
         }
     }
-    
+
     struct FlutterSecureStorageRequest {
         var accountName: String?
         var groupId: String?
@@ -224,5 +224,4 @@ public class SwiftFlutterSecureStoragePlugin: NSObject, FlutterPlugin, FlutterSt
         var key: String?
         var value: String?
     }
-    
 }

--- a/flutter_secure_storage/pubspec.yaml
+++ b/flutter_secure_storage/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_secure_storage
 description: Flutter Secure Storage provides API to store data in secure storage. Keychain is used in iOS, KeyStore based solution is used in Android.
-version: 9.2.2
+version: 9.2.3
 repository: https://github.com/mogol/flutter_secure_storage/tree/develop/flutter_secure_storage
 
 environment:


### PR DESCRIPTION
My suggestion for fixing bugs 25299 and 25300, which have existed on iOS since version greater than 9.0.0.

Original issue: The specified item already exists in the keychain, IOS #711

The problem occurred when the parameter kSecAttrAccessible was used to check whether a certain key already exists. The parameters kSecAttrAccount and kSecAttrAccessible together are not unique. The key kSecAttrAccount can therefore only occur once, even if kSecAttrAccessible is different.

In addition, kSecAttrAccessible cannot be changed by SecItemUpdate. This requires the key to be deleted and recreated.