### PR TITLE
json.dump with indentations for linux

### DIFF
--- a/flutter_secure_storage_linux/linux/include/Secret.hpp
+++ b/flutter_secure_storage_linux/linux/include/Secret.hpp
@@ -60,7 +60,7 @@ public:
   bool deleteKeyring() { return this->storeToKeyring(nlohmann::json()); }
 
   bool storeToKeyring(nlohmann::json value) {
-    const std::string output = value.dump();
+    const std::string output = value.dump(0);
     g_autoptr(GError) err = nullptr;
     bool result = secret_password_storev_sync(
         &the_schema, m_attributes.getGHashTable(), nullptr, label.c_str(),


### PR DESCRIPTION
As it was still bugging me I did some debugging of #747. A bit of bisecting gave me that 647a5d1035444959dc9c3034a78a13154493b2dc introduced the problem. Though there is nothing obviously wrong in it, it does the same thing the previous json lib did. Upon further debugging, printing out the logs, I couldn't find any significant difference but when writing with the new lib, the following reads wouldn't always return values. While with the old lib all was fine. Reading the old values also seemed to do fine, but writing with the new lib it didn't mean either old or new would find them. Printing the values I noticed the old lib was indenting the output in multiline, so I tried the same for the new lib, which by default uses the "most compact" version (which is reasonable) and that somehow fixes the problem. Just having the store string become multiline and it works. I don't understand why, but this consistently fixes the problem for me here. Weird.

Fixes #747 .

